### PR TITLE
Fix: todos in datagraph and nodeop replacement bug

### DIFF
--- a/rapx/src/analysis/core/dataflow/graph.rs
+++ b/rapx/src/analysis/core/dataflow/graph.rs
@@ -54,6 +54,7 @@ pub enum EdgeOp {
     Index,
     ConstIndex,
     SubSlice,
+    SubType,
 }
 
 #[derive(Clone)]
@@ -166,6 +167,9 @@ impl Graph {
                 PlaceElem::Subslice { .. } => {
                     graph.add_node_edge(src, dst, EdgeOp::SubSlice);
                 }
+                PlaceElem::Subtype (..) => {
+                    graph.add_node_edge(src, dst, EdgeOp::SubType);
+                }
                 _ => {
                     println!("{:?}", place_elem);
                     todo!()
@@ -237,6 +241,9 @@ impl Graph {
                         AggregateKind::Closure(def_id, ..) => {
                             self.nodes[dst].op = NodeOp::Aggregate(AggKind::Closure(def_id))
                         }
+                        AggregateKind::Coroutine(def_id, ..) => {
+                            self.nodes[dst].op = NodeOp::Aggregate(AggKind::Coroutine(def_id))
+                        }
                         _ => {
                             println!("{:?}", statement);
                             todo!()
@@ -294,7 +301,7 @@ impl Graph {
                             self.nodes[dst].op = NodeOp::Call(*def_id);
                         }
                     }
-                },
+                }
                 Operand::Move(_) => {
                     self.add_operand(func, dst); //the func is a place
                     for op in args.iter() {
@@ -302,8 +309,8 @@ impl Graph {
                         self.add_operand(&op.node, dst);
                     }
                     self.nodes[dst].op = NodeOp::CallOperand;
-                },
-                _ =>  {
+                }
+                _ => {
                     println!("{:?}", func);
                     todo!();
                 }
@@ -485,7 +492,8 @@ impl Graph {
             | EdgeOp::Field(_)
             | EdgeOp::Index
             | EdgeOp::ConstIndex
-            | EdgeOp::SubSlice => DFSStatus::Stop,
+            | EdgeOp::SubSlice
+            | EdgeOp::SubType => DFSStatus::Stop,
         }
     }
 
@@ -512,4 +520,5 @@ pub enum AggKind {
     Tuple,
     Adt(DefId),
     Closure(DefId),
+    Coroutine(DefId),
 }

--- a/rapx/src/analysis/core/dataflow/graph.rs
+++ b/rapx/src/analysis/core/dataflow/graph.rs
@@ -62,14 +62,14 @@ pub struct GraphEdge {
     pub src: Local,
     pub dst: Local,
     pub op: EdgeOp,
-    pub seq: u32,
+    pub seq: usize,
 }
 
 #[derive(Clone)]
 pub struct GraphNode {
-    pub op: NodeOp,
+    pub ops: Vec<NodeOp>,
     pub span: Span, //the corresponding code span
-    pub seq: u32, //the sequence number, edges with the same seq number are added in the same batch within a statement or terminator
+    pub seq: usize, //the sequence number, edges with the same seq number are added in the same batch within a statement or terminator
     pub out_edges: Vec<EdgeIdx>,
     pub in_edges: Vec<EdgeIdx>,
 }
@@ -77,7 +77,7 @@ pub struct GraphNode {
 impl GraphNode {
     pub fn new() -> Self {
         Self {
-            op: NodeOp::Nop,
+            ops: vec![NodeOp::Nop],
             span: DUMMY_SP,
             seq: 0,
             out_edges: vec![],
@@ -110,6 +110,7 @@ impl Graph {
         }
     }
 
+    // add an edge into an existing node
     pub fn add_node_edge(&mut self, src: Local, dst: Local, op: EdgeOp) -> EdgeIdx {
         let seq = self.nodes[dst].seq;
         let edge_idx = self.edges.push(GraphEdge { src, dst, op, seq });
@@ -118,10 +119,11 @@ impl Graph {
         edge_idx
     }
 
+    // add an edge into an existing node with const value as src
     pub fn add_const_edge(&mut self, src: String, dst: Local, op: EdgeOp) -> EdgeIdx {
         let seq = self.nodes[dst].seq;
         let mut const_node = GraphNode::new();
-        const_node.op = NodeOp::Const(src);
+        const_node.ops[0] = NodeOp::Const(src);
         let src = self.nodes.push(const_node);
         let edge_idx = self.edges.push(GraphEdge { src, dst, op, seq });
         self.nodes[dst].in_edges.push(edge_idx);
@@ -167,7 +169,7 @@ impl Graph {
                 PlaceElem::Subslice { .. } => {
                     graph.add_node_edge(src, dst, EdgeOp::SubSlice);
                 }
-                PlaceElem::Subtype (..) => {
+                PlaceElem::Subtype(..) => {
                     graph.add_node_edge(src, dst, EdgeOp::SubType);
                 }
                 _ => {
@@ -191,14 +193,19 @@ impl Graph {
             let dst = self.parse_place(&place);
             self.nodes[dst].span = statement.source_info.span;
             let rvalue = &boxed_statm.1;
+            let seq = self.nodes[dst].seq;
+            if seq == self.nodes[dst].ops.len() {
+                //warning: we do not check whether seq > len
+                self.nodes[dst].ops.push(NodeOp::Nop);
+            }
             match rvalue {
                 Rvalue::Use(op) => {
                     self.add_operand(op, dst);
-                    self.nodes[dst].op = NodeOp::Use;
+                    self.nodes[dst].ops[seq] = NodeOp::Use;
                 }
                 Rvalue::Repeat(op, _) => {
                     self.add_operand(op, dst);
-                    self.nodes[dst].op = NodeOp::Repeat;
+                    self.nodes[dst].ops[seq] = NodeOp::Repeat;
                 }
                 Rvalue::Ref(_, borrow_kind, place) => {
                     let op = match borrow_kind {
@@ -208,21 +215,21 @@ impl Graph {
                     };
                     let src = self.parse_place(place);
                     self.add_node_edge(src, dst, op);
-                    self.nodes[dst].op = NodeOp::Ref;
+                    self.nodes[dst].ops[seq] = NodeOp::Ref;
                 }
                 Rvalue::Len(place) => {
                     let src = self.parse_place(place);
                     self.add_node_edge(src, dst, EdgeOp::Nop);
-                    self.nodes[dst].op = NodeOp::Len;
+                    self.nodes[dst].ops[seq] = NodeOp::Len;
                 }
                 Rvalue::Cast(_cast_kind, operand, _) => {
                     self.add_operand(operand, dst);
-                    self.nodes[dst].op = NodeOp::Cast;
+                    self.nodes[dst].ops[seq] = NodeOp::Cast;
                 }
                 Rvalue::BinaryOp(_, operands) => {
                     self.add_operand(&operands.0, dst);
                     self.add_operand(&operands.1, dst);
-                    self.nodes[dst].op = NodeOp::CheckedBinaryOp;
+                    self.nodes[dst].ops[seq] = NodeOp::CheckedBinaryOp;
                 }
                 Rvalue::Aggregate(boxed_kind, operands) => {
                     for operand in operands.iter() {
@@ -230,19 +237,19 @@ impl Graph {
                     }
                     match **boxed_kind {
                         AggregateKind::Array(_) => {
-                            self.nodes[dst].op = NodeOp::Aggregate(AggKind::Array)
+                            self.nodes[dst].ops[seq] = NodeOp::Aggregate(AggKind::Array)
                         }
                         AggregateKind::Tuple => {
-                            self.nodes[dst].op = NodeOp::Aggregate(AggKind::Tuple)
+                            self.nodes[dst].ops[seq] = NodeOp::Aggregate(AggKind::Tuple)
                         }
                         AggregateKind::Adt(def_id, ..) => {
-                            self.nodes[dst].op = NodeOp::Aggregate(AggKind::Adt(def_id))
+                            self.nodes[dst].ops[seq] = NodeOp::Aggregate(AggKind::Adt(def_id))
                         }
                         AggregateKind::Closure(def_id, ..) => {
-                            self.nodes[dst].op = NodeOp::Aggregate(AggKind::Closure(def_id))
+                            self.nodes[dst].ops[seq] = NodeOp::Aggregate(AggKind::Closure(def_id))
                         }
                         AggregateKind::Coroutine(def_id, ..) => {
-                            self.nodes[dst].op = NodeOp::Aggregate(AggKind::Coroutine(def_id))
+                            self.nodes[dst].ops[seq] = NodeOp::Aggregate(AggKind::Coroutine(def_id))
                         }
                         _ => {
                             println!("{:?}", statement);
@@ -252,11 +259,11 @@ impl Graph {
                 }
                 Rvalue::UnaryOp(_, operand) => {
                     self.add_operand(operand, dst);
-                    self.nodes[dst].op = NodeOp::UnaryOp;
+                    self.nodes[dst].ops[seq] = NodeOp::UnaryOp;
                 }
                 Rvalue::NullaryOp(_, ty) => {
                     self.add_const_edge(ty.to_string(), dst, EdgeOp::Nop);
-                    self.nodes[dst].op = NodeOp::NullaryOp;
+                    self.nodes[dst].ops[seq] = NodeOp::NullaryOp;
                 }
                 Rvalue::ThreadLocalRef(_) => {
                     todo!()
@@ -264,20 +271,20 @@ impl Graph {
                 Rvalue::Discriminant(place) => {
                     let src = self.parse_place(place);
                     self.add_node_edge(src, dst, EdgeOp::Nop);
-                    self.nodes[dst].op = NodeOp::Discriminant;
+                    self.nodes[dst].ops[seq] = NodeOp::Discriminant;
                 }
                 Rvalue::ShallowInitBox(operand, _) => {
                     self.add_operand(operand, dst);
-                    self.nodes[dst].op = NodeOp::ShallowInitBox;
+                    self.nodes[dst].ops[seq] = NodeOp::ShallowInitBox;
                 }
                 Rvalue::CopyForDeref(place) => {
                     let src = self.parse_place(place);
                     self.add_node_edge(src, dst, EdgeOp::Nop);
-                    self.nodes[dst].op = NodeOp::CopyForDeref;
+                    self.nodes[dst].ops[seq] = NodeOp::CopyForDeref;
                 }
                 Rvalue::RawPtr(_, _) => todo!(),
             };
-            self.nodes[dst].seq += 1;
+            self.nodes[dst].seq = seq + 1;
         }
     }
 
@@ -290,6 +297,10 @@ impl Graph {
         } = &terminator.kind
         {
             let dst = destination.local;
+            let seq = self.nodes[dst].seq;
+            if seq == self.nodes[dst].ops.len() {
+                self.nodes[dst].ops.push(NodeOp::Nop);
+            }
             match func {
                 Operand::Constant(boxed_cnst) => {
                     if let Const::Val(_, ty) = boxed_cnst.const_ {
@@ -298,7 +309,7 @@ impl Graph {
                                 //rustc version related
                                 self.add_operand(&op.node, dst);
                             }
-                            self.nodes[dst].op = NodeOp::Call(*def_id);
+                            self.nodes[dst].ops[seq] = NodeOp::Call(*def_id);
                         }
                     }
                 }
@@ -308,7 +319,7 @@ impl Graph {
                         //rustc version related
                         self.add_operand(&op.node, dst);
                     }
-                    self.nodes[dst].op = NodeOp::CallOperand;
+                    self.nodes[dst].ops[seq] = NodeOp::CallOperand;
                 }
                 _ => {
                     println!("{:?}", func);
@@ -316,36 +327,54 @@ impl Graph {
                 }
             }
             self.nodes[dst].span = terminator.source_info.span;
-            self.nodes[dst].seq += 1;
+            self.nodes[dst].seq = seq + 1;
         }
     }
 
-    pub fn collect_equivalent_locals(&self, local: Local) -> HashSet<Local> {
+    // Because a node(local) may have multiple ops, we need to decide whether to strictly collect equivalent locals or not
+    // For the former, all the ops should meet the equivalent condition.
+    // For the later, if only one op meets the condition, we still take it into consideration.
+    pub fn collect_equivalent_locals(&self, local: Local, strict: bool) -> HashSet<Local> {
         let mut set = HashSet::new();
         let mut root = local;
+        let reduce_func = if strict {
+            DFSStatus::and
+        } else {
+            DFSStatus::or
+        };
         let mut find_root_operator = |graph: &Graph, idx: Local| -> DFSStatus {
             let node = &graph.nodes[idx];
-            match node.op {
-                NodeOp::Nop | NodeOp::Use | NodeOp::Ref => {
-                    //Nop means an orphan node or a parameter
-                    root = idx;
-                    DFSStatus::Continue
-                }
-                _ => DFSStatus::Stop,
-            }
+            node.ops
+                .iter()
+                .map(|op| {
+                    match op {
+                        NodeOp::Nop | NodeOp::Use | NodeOp::Ref => {
+                            //Nop means an orphan node or a parameter
+                            root = idx;
+                            DFSStatus::Continue
+                        }
+                        _ => DFSStatus::Stop,
+                    }
+                })
+                .reduce(reduce_func)
+                .unwrap()
         };
         let mut find_equivalent_operator = |graph: &Graph, idx: Local| -> DFSStatus {
             let node = &graph.nodes[idx];
             if set.contains(&idx) {
                 return DFSStatus::Stop;
             }
-            match node.op {
-                NodeOp::Nop | NodeOp::Use | NodeOp::Ref => {
-                    set.insert(idx);
-                    DFSStatus::Continue
-                }
-                _ => DFSStatus::Stop,
-            }
+            node.ops
+                .iter()
+                .map(|op| match op {
+                    NodeOp::Nop | NodeOp::Use | NodeOp::Ref => {
+                        set.insert(idx);
+                        DFSStatus::Continue
+                    }
+                    _ => DFSStatus::Stop,
+                })
+                .reduce(reduce_func)
+                .unwrap()
         };
         // Algorithm: dfs along upside to find the root node, and then dfs along downside to collect equivalent locals
         self.dfs(
@@ -510,8 +539,26 @@ pub enum Direction {
 }
 
 pub enum DFSStatus {
-    Continue,
-    Stop,
+    Continue, // true
+    Stop,     // false
+}
+
+impl DFSStatus {
+    pub fn and(s1: DFSStatus, s2: DFSStatus) -> DFSStatus {
+        if matches!(s1, DFSStatus::Stop) || matches!(s2, DFSStatus::Stop) {
+            DFSStatus::Stop
+        } else {
+            DFSStatus::Continue
+        }
+    }
+
+    pub fn or(s1: DFSStatus, s2: DFSStatus) -> DFSStatus {
+        if matches!(s1, DFSStatus::Continue) || matches!(s2, DFSStatus::Continue) {
+            DFSStatus::Continue
+        } else {
+            DFSStatus::Stop
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/rapx/src/analysis/opt.rs
+++ b/rapx/src/analysis/opt.rs
@@ -3,12 +3,18 @@ pub mod memory_cloning;
 
 use rustc_middle::ty::TyCtxt;
 
-use super::core::dataflow::DataFlow;
-use checking::bounds_checking;
-use memory_cloning::used_as_immutable;
+use super::core::dataflow::{graph::Graph, DataFlow};
+use checking::bounds_checking::BoundsCheck;
+use memory_cloning::used_as_immutable::UsedAsImmutableCheck;
 
 pub struct Opt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
+}
+
+pub trait OptCheck {
+    fn new() -> Self;
+    fn check(&mut self, graph: &Graph, tcx: &TyCtxt);
+    fn report(&self, graph: &Graph);
 }
 
 impl<'tcx> Opt<'tcx> {
@@ -19,9 +25,31 @@ impl<'tcx> Opt<'tcx> {
     pub fn start(&mut self) {
         let mut dataflow = DataFlow::new(self.tcx, false);
         dataflow.build_graphs();
-        for (_, graph) in dataflow.graphs.iter() {
-            bounds_checking::check(graph, &self.tcx);
-            used_as_immutable::check(graph, &self.tcx);
+        let bounds_checks: Vec<BoundsCheck> = dataflow
+            .graphs
+            .iter()
+            .map(|(_, graph)| {
+                let mut bounds_check = BoundsCheck::new();
+                bounds_check.check(graph, &self.tcx);
+                bounds_check
+            })
+            .collect();
+        let used_as_immutable_checks: Vec<UsedAsImmutableCheck> = dataflow
+            .graphs
+            .iter()
+            .map(|(_, graph)| {
+                let mut used_as_immutable_check = UsedAsImmutableCheck::new();
+                used_as_immutable_check.check(graph, &self.tcx);
+                used_as_immutable_check
+            })
+            .collect();
+        for ((_, graph), bounds_check) in dataflow.graphs.iter().zip(bounds_checks.iter()) {
+            bounds_check.report(graph);
+        }
+        for ((_, graph), used_as_immutable_check) in
+            dataflow.graphs.iter().zip(used_as_immutable_checks.iter())
+        {
+            used_as_immutable_check.report(graph);
         }
     }
 }

--- a/rapx/src/analysis/opt/checking/bounds_checking.rs
+++ b/rapx/src/analysis/opt/checking/bounds_checking.rs
@@ -1,11 +1,34 @@
 use rustc_middle::ty::TyCtxt;
 
 use crate::analysis::core::dataflow::graph::Graph;
+use crate::analysis::opt::OptCheck;
 
 pub mod bounds_len;
 pub mod bounds_loop_push;
 
-pub fn check(graph: &Graph, tcx: &TyCtxt) {
-    bounds_len::check(graph, tcx);
-    bounds_loop_push::check(graph, tcx);
+use bounds_len::BoundsLenCheck;
+use bounds_loop_push::BoundsLoopPushCheck;
+
+pub struct BoundsCheck {
+    bounds_len: BoundsLenCheck,
+    bounds_loop_push: BoundsLoopPushCheck,
+}
+
+impl OptCheck for BoundsCheck {
+    fn new() -> Self {
+        Self {
+            bounds_len: BoundsLenCheck::new(),
+            bounds_loop_push: BoundsLoopPushCheck::new(),
+        }
+    }
+
+    fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
+        self.bounds_len.check(graph, tcx);
+        self.bounds_loop_push.check(graph, tcx);
+    }
+
+    fn report(&self, graph: &Graph) {
+        self.bounds_len.report(graph);
+        self.bounds_loop_push.report(graph);
+    }
 }

--- a/rapx/src/analysis/opt/memory_cloning/hash_key_cloning.rs
+++ b/rapx/src/analysis/opt/memory_cloning/hash_key_cloning.rs
@@ -73,10 +73,12 @@ fn find_first_param_upside_clone(graph: &Graph, node: &GraphNode) -> Option<Loca
     let target_def_id = def_paths.clone.last_def_id();
     let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
         let node = &graph.nodes[idx];
-        if let NodeOp::Call(def_id) = node.op {
-            if def_id == target_def_id {
-                clone_node_idx = Some(idx);
-                return DFSStatus::Stop;
+        for op in node.ops.iter() {
+            if let NodeOp::Call(def_id) = op {
+                if *def_id == target_def_id {
+                    clone_node_idx = Some(idx);
+                    return DFSStatus::Stop;
+                }
             }
         }
         DFSStatus::Continue
@@ -98,10 +100,12 @@ fn find_hashset_new_node(graph: &Graph, node: &GraphNode) -> Option<Local> {
     let target_def_id = def_paths.hashset_new.last_def_id();
     let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
         let node = &graph.nodes[idx];
-        if let NodeOp::Call(def_id) = node.op {
-            if def_id == target_def_id {
-                new_node_idx = Some(idx);
-                return DFSStatus::Stop;
+        for op in node.ops.iter() {
+            if let NodeOp::Call(def_id) = op {
+                if *def_id == target_def_id {
+                    new_node_idx = Some(idx);
+                    return DFSStatus::Stop;
+                }
             }
         }
         DFSStatus::Continue


### PR DESCRIPTION
- Some match arms in datagraph have been implemented now to avoid panic
- **Change the basic field op in the GraphNode.**
  - Previously, our datagraph was build upon a hypothesis that every `Local` in MIR should be assigned for once and only once.
  - While actually we found that a Local can be assigned for multiple times. Thus I added the `seq` marker in edges to differentiate between edges.
  - However, the nodeop also needs to save the previous one and keep every record available.
  - In this PR, the `op` field is replaced by `ops` which is a `Vec<NodeOp>` and corresponding codes are also revised.