### PR TITLE
fix: better install user experience for z3

### DIFF
--- a/rapx/Cargo.toml
+++ b/rapx/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4"
 snafu = "0.7.0"
 chrono = "0.4.19"
 serde_json = "1.0.72"
-z3 = "0.12.1"
+z3 = {version="0.12.1", features = ["static-link-z3"]}
 log = "0.4.14"
 fern = {version = "0.6.2", features = ["colored"]}
 wait-timeout = "0.2.0"


### PR DESCRIPTION
This patch is for better install experience for z3
for most z3 compile like Mac M1-M4 and arm system, its hard for new user to install z3.h in their env,
This patch use static-link to easy user install.

More info can check: https://github.com/prove-rs/z3.rs/issues/224
#2 and #58