### PR TITLE
add core&alloc sp check

### DIFF
--- a/rapx/Cargo.toml
+++ b/rapx/Cargo.toml
@@ -35,6 +35,7 @@ once_cell = "1.20.1"
 walkdir = "2"
 cargo_metadata  = "0.18"
 annotate-snippets = "0.11.4"
+petgraph = "0.7.0"
 
 [features]
 backtraces = ["snafu/backtraces", "snafu/backtraces-impl-backtrace-crate"]

--- a/rapx/src/analysis/senryx/visitor.rs
+++ b/rapx/src/analysis/senryx/visitor.rs
@@ -282,6 +282,10 @@ impl<'tcx> BodyVisitor<'tcx> {
     ) {
         if !self.tcx.is_mir_available(def_id) {
             return;
+        } else {
+            let body = self.tcx.optimized_mir(def_id);
+            display_mir(*def_id, body);
+            // println!("{:?} has blocks {:?}",def_id, body.basic_blocks.len());
         }
 
         // get pre analysis state

--- a/rapx/src/analysis/unsafety_isolation/data/std_sps.json
+++ b/rapx/src/analysis/unsafety_isolation/data/std_sps.json
@@ -1,0 +1,1460 @@
+{
+    "core::alloc::global::GlobalAlloc::alloc": {
+      "sp": [
+        "ValidInt",
+        "Init"
+      ]
+    },
+    "core::alloc::global::GlobalAlloc::realloc": {
+      "sp": [
+        "AllocatorConsistency",
+        "LayoutConsistency",
+        "ValidInt"
+      ]
+    },
+    "core::alloc::global::GlobalAlloc::dealloc": {
+      "sp": [
+        "AllocatorConsistency",
+        "LayoutConsistency"
+      ]
+    },
+    "core::alloc::global::GlobalAlloc::alloc_zeroed": {
+      "sp": [
+        "ValidInt"
+      ]
+    },
+    "core::alloc::layout::from_size_align_unchecked": {
+      "sp": [
+        "ValidInt"
+      ]
+    },
+    "core::alloc::layout::for_value_raw": {
+        "sp": [
+          "Sized",
+          "!Sized && ValidSlice",
+          "!Sized && ValidTraitObj"
+        ]
+      },
+    "core::alloc::Allocator::grow": {
+      "sp": [
+        "AllocatorConsistency",
+        "LayoutConsistency",
+        "ValidInt"
+      ]
+    },
+    "core::alloc::Allocator::grow_zeroed": {
+      "sp": [
+        "AllocatorConsistency",
+        "LayoutConsistency",
+        "ValidInt"
+      ]
+    },
+    "core::alloc::Allocator::shrink": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency",
+            "ValidInt"
+        ]
+    },
+    "core::alloc::Allocator::deallocate": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency"
+        ]
+    },
+    "core::alloc::deallocate": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency"
+        ]
+    },
+    "core::alloc::grow": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency",
+            "ValidInt"
+        ]
+    },
+    "core::alloc::grow_zeroed": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency",
+            "ValidInt"
+        ]
+    },
+    "core::alloc::shrink": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency",
+            "ValidInt"
+        ]
+    },
+    "core::any::downcast_ref_unchecked": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::any::downcast_mut_unchecked": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::array::iter::new_unchecked": {
+        "sp": [
+            "ValidInt",
+            "Init"
+        ]
+    },
+    "core::array::ascii::as_ascii_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::ascii::ascii_char::digit_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::ascii::ascii_char::from_u8_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::cell::try_borrow_unguarded": {
+        "sp": [
+            "Alias"
+        ]
+    },
+    "core::char::from_u32_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::f128::to_int_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::f64::to_int_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::f32::to_int_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::f16::to_int_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::ffi::c_str::from_ptr": {
+        "sp": [
+            "ValidCStr",
+            "ValidPtr",
+            "NonNull",
+            "Alias",
+            "ValidInt"
+        ]
+    },
+    "core::ffi::c_str::from_bytes_with_nul_unchecked": {
+        "sp": [
+            "ValidCStr"
+        ]
+    },
+    "core::future::async_drop::async_drop_in_place": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::iter::range::forward_unchecked": {
+        "sp": [
+            "Allocated"
+        ]
+    },
+    "core::iter::range::backward_unchecked": {
+        "sp": [
+            "Allocated"
+        ]
+    },
+    "core::iter::range::Step::forward_unchecked": {
+        "sp": [
+            "Allocated"
+        ]
+    },
+    "core::iter::range::Step::backward_unchecked": {
+        "sp": [
+            "Allocated"
+        ]
+    },
+    "core::mem::manually_drop::take": {
+        "sp": [
+            "NonOwned"
+        ]
+    },
+    "core::mem::manually_drop::drop": {
+        "sp": [
+            "Dangling"
+        ]
+    },
+    "core::mem::maybe_uninit::assume_init": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::mem::maybe_uninit::assume_init_read": {
+        "sp": [
+            "Init",
+            "CopyTrait"
+        ]
+    },
+    "core::mem::maybe_uninit::assume_init_drop": {
+        "sp": [
+            "Init",
+            "Dangling"
+        ]
+    },
+    "core::mem::maybe_uninit::assume_init_ref": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::mem::maybe_uninit::assume_init_mut": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::mem::maybe_uninit::array_assume_init": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::mem::maybe_uninit::slice_assume_init_ref": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::mem::maybe_uninit::slice_assume_init_mut": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::mem::size_of_val_raw": {
+        "sp": [
+            "Sized",
+            "!Sized && ValidSlice",
+            "!Sized && ValidTraitObj"
+        ]
+    },
+    "core::mem::align_of_val_raw": {
+        "sp": [
+            "Sized",
+            "!Sized && ValidSlice",
+            "!Sized && ValidTraitObj"
+        ]
+    },
+    "core::mem::zeroed": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::mem::uninitialized": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::mem::transmute_copy": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::nonzero::unchecked_add": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::nonzero::unchecked_mul": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::nonzero::new_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::nonzero::from_mut_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::unchecked_sub": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::unchecked_mul": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::unchecked_neg": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::unchecked_shl": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::unchecked_shr": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::num::unchecked_add": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::hint::unreachable_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::hint::assert_unchecked": {
+        "sp": [
+            "Unreachable"
+        ]
+    },
+    "core::pin::map_unchecked": {
+        "sp": [
+            "Pinned"
+        ]
+    },
+    "core::pin::map_unchecked_mut": {
+        "sp": [
+            "Pinned"
+        ]
+    },
+    "core::pin::new_unchecked": {
+        "sp": [
+            "Pinned"
+        ]
+    },
+    "core::pin::into_inner_unchecked": {
+        "sp": [
+            "Pinned"
+        ]
+    },
+    "core::pin::get_unchecked_mut": {
+        "sp": [
+            "Pinned"
+        ]
+    },
+    "core::sync::atomic::from_ptr": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Alias",
+            "Lifetime"
+        ]
+    },
+    "core::intrinsics::copy": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonVolatile",
+            "Alias",
+            "CopyTrait"
+        ]
+    },
+    "core::intrinsics::copy::copy": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonVolatile",
+            "Alias",
+            "CopyTrait"
+        ]
+    },
+    "core::intrinsics::copy_nonoverlapping": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonOverlap",
+            "NonVolatile",
+            "Alias",
+            "CopyTrait"
+        ]
+    },
+    "core::ptr::alignment::new_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::ptr::non_null::as_uninit_ref": {
+        "sp": [
+            "!NonNull | ",
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::non_null::as_uninit_mut": {
+        "sp": [
+            "!NonNull | ",
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::non_null::new_unchecked": {
+        "sp": [
+            "NonNull"
+        ]
+    },
+    "core::ptr::non_null::as_ref": {
+        "sp": [
+            "!NonNull | ",
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::non_null::as_mut": {
+        "sp": [
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::non_null::offset": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::non_null::add": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::non_null::byte_offset": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::non_null::byte_add": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::non_null::sub": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::non_null::read": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::non_null::read_volatile": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::non_null::read_unaligned": {
+        "sp": [
+            "ValidPtr",
+            "Init"
+        ]
+    },
+    "core::ptr::non_null::copy_to": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::non_null::copy_to_nonoverlapping": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonOverlap"
+        ]
+    },
+    "core::ptr::non_null::copy_from": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::non_null::copy_from_nonoverlapping": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonOverlap"
+        ]
+    },
+    "core::ptr::non_null::drop_in_place": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonNull"
+        ]
+    },
+    "core::ptr::non_null::write": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::non_null::write_bytes": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::non_null::write_volatile": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::non_null::write_unaligned": {
+        "sp": [
+            "ValidPtr",
+            "Init"
+        ]
+    },
+    "core::ptr::non_null::replace": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::non_null::swap": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::non_null::as_uninit_slice": {
+        "sp": [
+            "!NonNull ||",
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::ptr::non_null::as_uninit_slice_mut": {
+        "sp": [
+            "!NonNull ||",
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::ptr::non_null::get_unchecked_mut": {
+        "sp": [
+            "ValidInt",
+            "Dangling"
+        ]
+    },
+
+    "core::ptr::const_ptr::as_ref": {
+        "sp": [
+            "!NonNull | ",
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::const_ptr::as_ref_unchecked": {
+        "sp": [
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::const_ptr::as_uninit_ref": {
+        "sp": [
+            "!NonNull | ",
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::const_ptr::offset": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::add": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::sub": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::byte_offset": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::offset_from": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::byte_offset_from": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::non_null::sub_ptr": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::sub_ptr": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::byte_add": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::byte_sub": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::const_ptr::read": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::const_ptr::read_volatile": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::const_ptr::read_unaligned": {
+        "sp": [
+            "ValidPtr",
+            "Init"
+        ]
+    },
+    "core::ptr::const_ptr::copy_to": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::const_ptr::copy_to_nonoverlapping": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonOverlap"
+        ]
+    },
+    "core::ptr::const_ptr::as_uninit_slice": {
+        "sp": [
+            "!NonNull ||",
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::ptr::const_ptr::get_unchecked": {
+        "sp": [
+            "ValidInt",
+            "Dangling"
+        ]
+    },
+
+
+
+    "core::ptr::mut_ptr::as_ref": {
+        "sp": [
+            "!NonNull | ",
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::mut_ptr::as_ref_unchecked": {
+        "sp": [
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::mut_ptr::as_uninit_ref": {
+        "sp": [
+            "!NonNull | ",
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::mut_ptr::offset": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::as_mut": {
+        "sp": [
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::mut_ptr::as_mut_unchecked": {
+        "sp": [
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::mut_ptr::as_uninit_mut": {
+        "sp": [
+            "!NonNull | ",
+            "ValidPtr2Ref"
+        ]
+    },
+    "core::ptr::mut_ptr::add": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::sub": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::byte_offset": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::offset_from": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::byte_offset_from": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::sub_ptr": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::byte_add": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::byte_sub": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "core::ptr::mut_ptr::read": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::mut_ptr::read_volatile": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::mut_ptr::read_unaligned": {
+        "sp": [
+            "ValidPtr",
+            "Init"
+        ]
+    },
+    "core::ptr::mut_ptr::copy_to": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::mut_ptr::copy_to_nonoverlapping": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonOverlap"
+        ]
+    },
+    "core::ptr::mut_ptr::copy_from": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::mut_ptr::copy_from_nonoverlapping": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonOverlap"
+        ]
+    },
+    "core::ptr::mut_ptr::drop_in_place": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonNull"
+        ]
+    },
+    "core::ptr::mut_ptr::write": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::mut_ptr::write_bytes": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::mut_ptr::write_volatile": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::mut_ptr::write_unaligned": {
+        "sp": [
+            "ValidPtr",
+            "Init"
+        ]
+    },
+    "core::ptr::mut_ptr::replace": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::mut_ptr::swap": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::mut_ptr::split_at_mut": {
+        "sp": [
+            "ValidInt",
+            "Dangling"
+        ]
+    },
+    "core::ptr::mut_ptr::split_at_mut_unchecked": {
+        "sp": [
+            "ValidInt",
+            "Dangling"
+        ]
+    },
+    "core::ptr::mut_ptr::as_uninit_slice": {
+        "sp": [
+            "!NonNull ||",
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::ptr::mut_ptr::as_uninit_slice_mut": {
+        "sp": [
+            "!NonNull ||",
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::ptr::mut_ptr::get_unchecked_mut": {
+        "sp": [
+            "ValidInt",
+            "Dangling"
+        ]
+    },
+
+    "core::ptr::drop_in_place": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonNull"
+        ]
+    },
+    "core::ptr::replace": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::read": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "Init"
+        ]
+    },
+    "core::ptr::write": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::swap": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+    "core::ptr::swap_nonoverlapping": {
+        "sp": [
+            "ValidPtr",
+            "Aligned",
+            "NonOverlap"
+        ]
+    },
+    "core::ptr::read_unaligned": {
+        "sp": [
+            "ValidPtr",
+            "Init"
+        ]
+    },
+    "core::ptr::write_unaligned": {
+        "sp": [
+            "ValidPtr",
+            "Init"
+        ]
+    },
+    "core::ptr::read_volatile": {
+        "sp": [
+            "ValidPtr",
+            "Init",
+            "Aligned"
+        ]
+    },
+    "core::ptr::write_volatile": {
+        "sp": [
+            "ValidPtr",
+            "Init",
+            "Aligned"
+        ]
+    },
+    "core::clone::clone_to_uninit": {
+        "sp": [
+            "ValidPtr",
+            "Aligned"
+        ]
+    },
+
+    "core::result::unwrap_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::result::unwrap_err_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::slice::ascii::as_ascii_unchecked": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::slice::raw::from_raw_parts": {
+        "sp": [
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::slice::raw::from_raw_parts_mut": {
+        "sp": [
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::slice::index::get_unchecked": {
+        "sp": [
+            "Dangling",
+            "Allocated"
+        ]
+    },
+    "core::slice::index::get_unchecked_mut": {
+        "sp": [
+            "Dangling",
+            "Allocated"
+        ]
+    },
+    "core::slice::raw::from_ptr_range": {
+        "sp": [
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::slice::raw::from_mut_ptr_range": {
+        "sp": [
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::str::get_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::str::get_unchecked_mut": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::str::slice_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::str::slice_mut_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::str::as_bytes_mut": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::str::converts::from_utf8_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::str::converts::from_utf8_unchecked_mut": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::str::converts::from_raw_parts": {
+        "sp": [
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::str::converts::from_raw_parts_mut": {
+        "sp": [
+            "NonNull",
+            "ValidPtr",
+            "Init",
+            "Lifetime",
+            "Alias",
+            "ValidInt",
+            "Aligned"
+        ]
+    },
+    "core::str::traits::get_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::str::traits::get_unchecked_mut": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "core::io::borrowed_buf::set_init": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::io::borrowed_buf::advance_unchecked": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "core::task::wake::from_raw": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+
+    "alloc::vec::from_raw_parts": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned",
+            "Allocated",
+            "ValidInt",
+            "LayoutConsistency"
+        ]
+    },
+    "alloc::vec::from_parts": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned",
+            "Allocated",
+            "ValidInt",
+            "LayoutConsistency"
+        ]
+    },
+    "alloc::vec::from_raw_parts_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned",
+            "Allocated",
+            "ValidInt",
+            "LayoutConsistency"
+        ]
+    },
+    "alloc::vec::from_parts_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned",
+            "Allocated",
+            "ValidInt",
+            "LayoutConsistency"
+        ]
+    },
+    "alloc::vec::set_len": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
+    "alloc::alloc::alloc": {
+        "sp": [
+            "ValidInt",
+            "Init"
+        ]
+    },
+    "alloc::alloc::dealloc": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency"
+        ]
+    },
+    "alloc::alloc::realloc": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency",
+            "ValidInt"
+        ]
+    },
+    "alloc::alloc::alloc_zeroed": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "alloc::alloc::deallocate": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency"
+        ]
+    },
+    "alloc::alloc::grow": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency",
+            "ValidInt"
+        ]
+    },
+    "alloc::alloc::grow_zeroed": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency",
+            "ValidInt"
+        ]
+    },
+    "alloc::alloc::shrink": {
+        "sp": [
+            "AllocatorConsistency",
+            "LayoutConsistency",
+            "ValidInt"
+        ]
+    },
+    "alloc::boxed::assume_init": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "alloc::boxed::from_raw": {
+        "sp": [
+            "AllocatorConsistency",
+            "Alias"
+        ]
+    },
+    "alloc::boxed::from_non_null": {
+        "sp": [
+            "AllocatorConsistency",
+            "Alias"
+        ]
+    },
+    "alloc::boxed::from_raw_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Alias"
+        ]
+    },
+    "alloc::boxed::from_non_null_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Alias"
+        ]
+    },
+    "alloc::boxed::downcast_unchecked": {
+        "sp": [
+            "Typed"
+        ]
+    },
+    "alloc::collections::btree::map::insert_after_unchecked": {
+        "sp": [
+            "",
+            ""
+        ]
+    },
+    "alloc::collections::btree::map::insert_before_unchecked": {
+        "sp": [
+            "",
+            ""
+        ]
+    },
+    "alloc::collections::btree::set::insert_after_unchecked": {
+        "sp": [
+            "",
+            ""
+        ]
+    },
+    "alloc::collections::btree::set::insert_before_unchecked": {
+        "sp": [
+            "",
+            ""
+        ]
+    },
+    "alloc::ffi::c_str::from_vec_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "alloc::ffi::c_str::from_raw": {
+        "sp": [
+            "AllocatorConsistency",
+            "Alias"
+        ]
+    },
+    "alloc::ffi::c_str::from_vec_with_nul_unchecked": {
+        "sp": [
+            "ValidCStr"
+        ]
+    },
+    "alloc::rc::assume_init": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "alloc::rc::from_raw": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned"
+        ]
+    },
+    "alloc::rc::increment_strong_count": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+    "alloc::rc::decrement_strong_count": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+    "alloc::rc::from_raw_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned"
+        ]
+    },
+    "alloc::rc::increment_strong_count_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+    "alloc::rc::decrement_strong_count_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+    "alloc::rc::downcast_unchecked": {
+        "sp": [
+            "Typed"
+        ]
+    },
+    "alloc::rc::get_mut_unchecked": {
+        "sp": [
+            "Typed",
+            "Alias"
+        ]
+    },
+    "alloc::collections::btree::map::with_mutable_key": {
+        "sp": [
+            "",
+            ""
+        ]
+    },
+    "alloc::collections::btree::set::upper_bound_mut": {
+        "sp": [
+            "",
+            ""
+        ]
+    },
+    "alloc::str::from_boxed_utf8_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "alloc::string::from_raw_parts": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned",
+            "ValidInt",
+            "ValidString"
+        ]
+    },
+    "alloc::string::from_utf8_unchecked": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "alloc::string::as_mut_vec": {
+        "sp": [
+            "ValidString"
+        ]
+    },
+    "alloc::sync::get_mut_unchecked": {
+        "sp": [
+            "Typed",
+            "Alias"
+        ]
+    },
+    "alloc::sync::from_raw": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned"
+        ]
+    },
+    "alloc::sync::increment_strong_count": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+    "alloc::sync::decrement_strong_count": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+    "alloc::sync::from_raw_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Aligned"
+        ]
+    },
+    "alloc::sync::increment_strong_count_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+    "alloc::sync::decrement_strong_count_in": {
+        "sp": [
+            "AllocatorConsistency",
+            "Dangling"
+        ]
+    },
+    "alloc::sync::downcast_unchecked": {
+        "sp": [
+            "Typed"
+        ]
+    }
+}  

--- a/rapx/src/analysis/unsafety_isolation/draw_dot.rs
+++ b/rapx/src/analysis/unsafety_isolation/draw_dot.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{remove_file, File};
 use std::io::Write;
 use std::process::Command;
 
@@ -24,5 +24,7 @@ pub fn render_dot_graphs(dot_graphs: Vec<String>) {
             ])
             .output()
             .expect("Failed to execute Graphviz dot command");
+
+        remove_file(&file_name).expect("Failed to delete .dot file");
     }
 }

--- a/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
+++ b/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
@@ -1,0 +1,218 @@
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::CRATE_DEF_INDEX;
+use rustc_middle::ty::Visibility;
+use rustc_middle::{
+    mir::{Operand, TerminatorKind},
+    ty,
+    ty::TyCtxt,
+};
+use std::collections::HashSet;
+// use crate::analysis::unsafety_isolation::draw_dot::render_dot_graphs;
+
+use super::{
+    generate_dot::{NodeType, UigUnit},
+    UnsafetyIsolationCheck,
+};
+
+impl<'tcx> UnsafetyIsolationCheck<'tcx> {
+    pub fn handle_std_unsafe(&mut self) {
+        self.get_all_std_unsafe_def_id_by_treat_std_as_local_crate(self.tcx);
+        let mut dot_strs = Vec::new();
+        for uig in &self.uigs {
+            let dot_str = uig.generate_dot_str();
+            uig.compare_labels();
+            dot_strs.push(dot_str);
+        }
+        for uig in &self.single {
+            let dot_str = uig.generate_dot_str();
+            // uig.compare_labels();
+            dot_strs.push(dot_str);
+        }
+        // println!("single {:?}",self.single.len());
+        // render_dot_graphs(dot_strs);
+    }
+
+    pub fn get_all_std_unsafe_def_id_by_rustc_extern_crates(
+        &mut self,
+        tcx: TyCtxt<'_>,
+    ) -> HashSet<DefId> {
+        let mut visited = HashSet::new();
+        let mut unsafe_fn = HashSet::new();
+        for &crate_num in tcx.crates(()).iter() {
+            let crate_name = tcx.crate_name(crate_num).to_string();
+            // if crate_name == "std" || crate_name == "core" || crate_name == "alloc" {
+            if crate_name == "core" {
+                let crate_root = DefId {
+                    krate: crate_num,
+                    index: CRATE_DEF_INDEX,
+                };
+                self.process_def_id(tcx, crate_root, &mut visited, &mut unsafe_fn);
+                println!(
+                    "{:?} has {:?} MIR instances totally, with {:?} unsafe fns.",
+                    crate_name,
+                    visited.len(),
+                    unsafe_fn.len()
+                );
+            }
+        }
+        // Self::print_hashset(&unsafe_fn);
+        unsafe_fn
+    }
+
+    pub fn get_all_std_unsafe_def_id_by_treat_std_as_local_crate(
+        &mut self,
+        tcx: TyCtxt<'_>,
+    ) -> HashSet<DefId> {
+        let mut unsafe_fn = HashSet::new();
+        let def_id_sets = tcx.mir_keys(());
+        for local_def_id in def_id_sets {
+            let def_id = local_def_id.to_def_id();
+            if Self::filter_mir(def_id) {
+                continue;
+            }
+            if tcx.def_kind(def_id) == DefKind::Fn || tcx.def_kind(def_id) == DefKind::AssocFn {
+                if self.check_safety(def_id) && self.tcx.visibility(def_id) == Visibility::Public {
+                    unsafe_fn.insert(def_id);
+                    self.insert_uig(def_id, self.get_callees(def_id), self.get_cons(def_id));
+                }
+            }
+        }
+        unsafe_fn
+    }
+
+    pub fn process_def_id(
+        &mut self,
+        tcx: TyCtxt<'_>,
+        def_id: DefId,
+        visited: &mut HashSet<DefId>,
+        unsafe_fn: &mut HashSet<DefId>,
+    ) {
+        if !visited.insert(def_id) || Self::filter_mir(def_id) {
+            return;
+        }
+        match tcx.def_kind(def_id) {
+            DefKind::Fn | DefKind::AssocFn => {
+                if self.check_safety(def_id) && self.tcx.visibility(def_id) == Visibility::Public {
+                    unsafe_fn.insert(def_id);
+                    self.insert_uig(def_id, self.get_callees(def_id), self.get_cons(def_id));
+                }
+            }
+            DefKind::Mod => {
+                for child in tcx.module_children(def_id) {
+                    if let Some(child_def_id) = child.res.opt_def_id() {
+                        self.process_def_id(tcx, child_def_id, visited, unsafe_fn);
+                    }
+                }
+            }
+            DefKind::Impl { of_trait: _ } => {
+                for item in tcx.associated_item_def_ids(def_id) {
+                    self.process_def_id(tcx, *item, visited, unsafe_fn);
+                }
+            }
+            DefKind::Struct => {
+                let impls = tcx.inherent_impls(def_id);
+                for impl_def_id in impls {
+                    self.process_def_id(tcx, *impl_def_id, visited, unsafe_fn);
+                }
+            }
+            DefKind::Ctor(_of, _kind) => {
+                if tcx.is_mir_available(def_id) {
+                    let _mir = tcx.optimized_mir(def_id);
+                }
+            }
+            _ => {
+                // println!("{:?}",tcx.def_kind(def_id));
+            }
+        }
+    }
+
+    pub fn filter_mir(def_id: DefId) -> bool {
+        let def_id_fmt = format!("{:?}", def_id);
+        def_id_fmt.contains("core_arch") || def_id_fmt.contains("::__")
+    }
+
+    pub fn insert_uig(
+        &mut self,
+        caller: DefId,
+        callee_set: HashSet<DefId>,
+        caller_cons: Vec<NodeType>,
+    ) {
+        let mut pairs = HashSet::new();
+        for callee in &callee_set {
+            let callee_cons = self.get_cons(*callee);
+            pairs.insert((self.generate_node_ty(*callee), callee_cons));
+        }
+        let uig = UigUnit::new_by_pair(self.generate_node_ty(caller), caller_cons, pairs);
+        if callee_set.len() > 0 {
+            self.uigs.push(uig);
+        } else {
+            self.single.push(uig);
+        }
+    }
+
+    pub fn get_cons(&self, def_id: DefId) -> Vec<NodeType> {
+        let mut cons = Vec::new();
+        if self.tcx.def_kind(def_id) == DefKind::Fn || self.get_type(def_id) == 0 {
+            return cons;
+        }
+        let tcx = self.tcx;
+        if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
+            if let Some(impl_id) = assoc_item.impl_container(tcx) {
+                // get struct ty
+                let ty = tcx.type_of(impl_id).skip_binder();
+                if let Some(adt_def) = ty.ty_adt_def() {
+                    let adt_def_id = adt_def.did();
+                    let impls = tcx.inherent_impls(adt_def_id);
+                    for impl_def_id in impls {
+                        for item in tcx.associated_item_def_ids(impl_def_id) {
+                            if (tcx.def_kind(item) == DefKind::Fn
+                                || tcx.def_kind(item) == DefKind::AssocFn)
+                                && self.get_type(*item) == 0
+                            {
+                                cons.push(self.generate_node_ty(*item));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        cons
+    }
+
+    pub fn get_callees(&self, def_id: DefId) -> HashSet<DefId> {
+        let mut callees = HashSet::new();
+        let tcx = self.tcx;
+        if tcx.is_mir_available(def_id) {
+            let body = tcx.optimized_mir(def_id);
+            for bb in body.basic_blocks.iter() {
+                match &bb.terminator().kind {
+                    TerminatorKind::Call { func, .. } => {
+                        if let Operand::Constant(func_constant) = func {
+                            if let ty::FnDef(ref callee_def_id, _) =
+                                func_constant.const_.ty().kind()
+                            {
+                                if self.check_safety(*callee_def_id) {
+                                    callees.insert(*callee_def_id);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        return callees;
+    }
+
+    pub fn generate_node_ty(&self, def_id: DefId) -> NodeType {
+        (def_id, self.check_safety(def_id), self.get_type(def_id))
+    }
+
+    pub fn print_hashset<T: std::fmt::Debug>(set: &HashSet<T>) {
+        for item in set {
+            println!("{:?}", item);
+        }
+        println!("---------------");
+    }
+}

--- a/rapx/src/bin/cargo-rapx/args.rs
+++ b/rapx/src/bin/cargo-rapx/args.rs
@@ -75,6 +75,9 @@ impl Arguments {
             None => return false,
         };
         entry_path.is_relative()
+        // || entry_path.ends_with("lib/rustlib/src/rust/library/std/src/lib.rs") 
+        || entry_path.ends_with("lib/rustlib/src/rust/library/core/src/lib.rs") 
+        || entry_path.ends_with("lib/rustlib/src/rust/library/alloc/src/lib.rs")
     }
 }
 


### PR DESCRIPTION
This PR adds the functionality to detect the safety properties (SP) of unsafe APIs in the standard library's core and alloc modules. Currently, it provides a basic comparison of whether the caller and callee have the same SP. More in-depth analysis will be added in the future.

Usage:

1. Create a new `helloworld` project.
2. Navigate to the `helloworld` project directory and run:
```
cargo rapx -upg -- -Z build-std --target x86_64-unknown-linux-gnu > /your/output/log/path/result.log 2>&1
(Replace /your/output/log/path with your desired output directory.)
```
This will output APIs where the caller and callee have different SPs.