### PR TITLE
Uphold safety to unsafe constructor

### DIFF
--- a/rapx/src/analysis/senryx.rs
+++ b/rapx/src/analysis/senryx.rs
@@ -56,19 +56,16 @@ impl<'tcx> SenryxCheck<'tcx> {
 
     pub fn annotate_safety(&self, def_id: DefId) {
         let annotation_results = self.get_anntation(def_id);
-        println!(
-            "--------In unsafe function {:?}---------\n  SP labels:  ",
+        rap_info!(
+            "--------In unsafe function {:?}---------",
             UigUnit::get_cleaned_def_path_name(def_id)
         );
-        for item in annotation_results {
-            print!("{:?} ", item);
-        }
-        print!("\n");
+        rap_warn!("Lack safety annotations: {:?}.", annotation_results);
     }
 
     pub fn body_visit_and_check(&self, def_id: DefId) -> Vec<CheckResult> {
         let mut uig_checker = UnsafetyIsolationCheck::new(self.tcx);
-        let func_type = uig_checker.get_type(def_id);
+        let func_type = UnsafetyIsolationCheck::get_type(self.tcx,def_id);
         let mut body_visitor = BodyVisitor::new(self.tcx, def_id, 0);
         if func_type == 1 {
             let func_cons = uig_checker.search_constructor(def_id);

--- a/rapx/src/analysis/senryx.rs
+++ b/rapx/src/analysis/senryx.rs
@@ -15,7 +15,8 @@ use rustc_middle::mir::{BasicBlock, Operand, TerminatorKind};
 use rustc_middle::ty;
 use rustc_middle::ty::TyCtxt;
 use std::collections::HashSet;
-use visitor::{BodyVisitor, CheckResult};
+use visitor::CheckResult;
+// use visitor::{BodyVisitor, CheckResult};
 
 use super::unsafety_isolation::generate_dot::UigUnit;
 
@@ -48,44 +49,55 @@ impl<'tcx> SenryxCheck<'tcx> {
     }
 
     pub fn check_soundness(&self, def_id: DefId) {
-        let check_results = self.body_visit_and_check(def_id);
-        if check_results.len() > 0 {
-            Self::show_check_results(def_id, check_results);
-        }
+        let _check_results = self.body_visit_and_check(def_id);
+        // if check_results.len() > 0 {
+        //     Self::show_check_results(def_id, check_results);
+        // }
     }
 
     pub fn annotate_safety(&self, def_id: DefId) {
-        let annotation_results = self.get_anntation(def_id);
-        rap_info!(
-            "--------In unsafe function {:?}---------",
-            UigUnit::get_cleaned_def_path_name(def_id)
-        );
-        rap_warn!("Lack safety annotations: {:?}.", annotation_results);
+        let annotation_results = self.get_annotation(def_id);
+        if annotation_results.len() == 0 {
+            return;
+        }
+        Self::show_annotate_results(def_id, annotation_results);
     }
 
-    pub fn body_visit_and_check(&self, def_id: DefId) -> Vec<CheckResult> {
+    // pub fn body_visit_and_check(&self, def_id: DefId) -> Vec<CheckResult> {
+    //     let mut uig_checker = UnsafetyIsolationCheck::new(self.tcx);
+    //     let func_type = UnsafetyIsolationCheck::get_type(self.tcx,def_id);
+    //     let mut body_visitor = BodyVisitor::new(self.tcx, def_id, 0);
+    //     if func_type == 1 {
+    //         let func_cons = uig_checker.search_constructor(def_id);
+    //         for func_con in func_cons {
+    //             let mut cons_body_visitor = BodyVisitor::new(self.tcx, func_con, 0);
+    //             cons_body_visitor.path_forward_check();
+    //             // TODO: cache fields' states
+    //             // TODO: update method body's states
+    //             // analyze body's states
+    //             body_visitor.path_forward_check();
+    //         }
+    //     } else {
+    //         body_visitor.path_forward_check();
+    //     }
+    //     return body_visitor.check_results;
+    // }
+
+    pub fn body_visit_and_check(&self, def_id: DefId) {
         let mut uig_checker = UnsafetyIsolationCheck::new(self.tcx);
-        let func_type = UnsafetyIsolationCheck::get_type(self.tcx,def_id);
-        let mut body_visitor = BodyVisitor::new(self.tcx, def_id, 0);
-        if func_type == 1 {
+        let func_type = UnsafetyIsolationCheck::get_type(self.tcx, def_id);
+        if func_type == 1 && self.get_annotation(def_id).len() > 0 {
             let func_cons = uig_checker.search_constructor(def_id);
             for func_con in func_cons {
-                let mut cons_body_visitor = BodyVisitor::new(self.tcx, func_con, 0);
-                cons_body_visitor.path_forward_check();
-                // TODO: cache fields' states
-
-                // TODO: update method body's states
-
-                // analyze body's states
-                body_visitor.path_forward_check();
+                if UnsafetyIsolationCheck::check_safety(self.tcx, func_con) {
+                    Self::show_annotate_results(func_con, self.get_annotation(def_id));
+                    // uphold safety to unsafe constructor
+                }
             }
-        } else {
-            body_visitor.path_forward_check();
         }
-        return body_visitor.check_results;
     }
 
-    pub fn get_anntation(&self, def_id: DefId) -> HashSet<String> {
+    pub fn get_annotation(&self, def_id: DefId) -> HashSet<String> {
         let mut results = HashSet::new();
         if !self.tcx.is_mir_available(def_id) {
             return results;
@@ -110,7 +122,7 @@ impl<'tcx> SenryxCheck<'tcx> {
                             if UigUnit::get_sp(*id).len() > 0 {
                                 results.extend(UigUnit::get_sp(*id));
                             } else {
-                                results.extend(self.get_anntation(*id));
+                                results.extend(self.get_annotation(*id));
                             }
                         }
                         _ => {}
@@ -139,5 +151,13 @@ impl<'tcx> SenryxCheck<'tcx> {
                 rap_warn!("      Contract failed: {:?}", failed_contract);
             }
         }
+    }
+
+    pub fn show_annotate_results(def_id: DefId, annotation_results: HashSet<String>) {
+        rap_info!(
+            "--------In unsafe function {:?}---------",
+            UigUnit::get_cleaned_def_path_name(def_id)
+        );
+        rap_warn!("Lack safety annotations: {:?}.", annotation_results);
     }
 }

--- a/rapx/src/analysis/unsafety_isolation.rs
+++ b/rapx/src/analysis/unsafety_isolation.rs
@@ -64,7 +64,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                         self.check_doc(def_id);
                     }
                     if ins == UigInstruction::Ucons {
-                        if Self::get_type(self.tcx,def_id) == 0 {
+                        if Self::get_type(self.tcx, def_id) == 0 {
                             println!(
                                 "Find unsafe constructor: {:?}, location:{:?}.",
                                 def_id, span
@@ -101,7 +101,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                     ContainsUnsafe::contains_unsafe(self.tcx, *body_id);
                 let body_did = hir_map.body_owner_def_id(*body_id).to_def_id();
                 if function_unsafe || block_unsafe {
-                    let node_type = Self::get_type(self.tcx,body_did);
+                    let node_type = Self::get_type(self.tcx, body_did);
                     let name = self.get_name(body_did);
                     let mut new_node =
                         IsolationGraphNode::new(body_did, node_type, name, function_unsafe, true);
@@ -218,7 +218,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                         for item in associated_items.in_definition_order() {
                             if let ty::AssocKind::Fn = item.kind {
                                 let item_def_id = item.def_id;
-                                if Self::get_type(self.tcx,item_def_id) == 0 {
+                                if Self::get_type(self.tcx, item_def_id) == 0 {
                                     constructors.push(item_def_id);
                                     self.check_and_insert_node(item_def_id);
                                     self.set_method_for_constructor(item_def_id, def_id);
@@ -248,9 +248,9 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                         for item in associated_items.in_definition_order() {
                             if let ty::AssocKind::Fn = item.kind {
                                 let item_def_id = item.def_id;
-                                if Self::get_type(self.tcx,item_def_id) == 0 {
+                                if Self::get_type(self.tcx, item_def_id) == 0 {
                                     constructors.push(item_def_id);
-                                } else if Self::get_type(self.tcx,item_def_id) == 1 {
+                                } else if Self::get_type(self.tcx, item_def_id) == 1 {
                                     methods.push(item_def_id);
                                 }
                             }
@@ -328,7 +328,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         if self.check_if_node_exists(body_did) {
             return;
         }
-        let node_type = Self::get_type(self.tcx,body_did);
+        let node_type = Self::get_type(self.tcx, body_did);
         let name = self.get_name(body_did);
         let is_crate_api = self.is_crate_api_node(body_did);
         let node_safety = Self::check_safety(self.tcx, body_did);

--- a/rapx/src/analysis/unsafety_isolation/data/std_sps.json
+++ b/rapx/src/analysis/unsafety_isolation/data/std_sps.json
@@ -1008,6 +1008,12 @@
             "Aligned"
         ]
     },
+    "core::ptr::offset": {
+        "sp": [
+            "Allocated",
+            "ValidInt"
+        ]
+    },
     "core::clone::clone_to_uninit": {
         "sp": [
             "ValidPtr",

--- a/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
+++ b/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
@@ -72,9 +72,15 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                 continue;
             }
             if tcx.def_kind(def_id) == DefKind::Fn || tcx.def_kind(def_id) == DefKind::AssocFn {
-                if Self::check_safety(tcx, def_id) && self.tcx.visibility(def_id) == Visibility::Public {
+                if Self::check_safety(tcx, def_id)
+                    && self.tcx.visibility(def_id) == Visibility::Public
+                {
                     unsafe_fn.insert(def_id);
-                    self.insert_uig(def_id, self.get_callees(def_id), Self::get_cons(tcx, def_id));
+                    self.insert_uig(
+                        def_id,
+                        self.get_callees(def_id),
+                        Self::get_cons(tcx, def_id),
+                    );
                 }
             }
         }
@@ -93,9 +99,15 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         }
         match tcx.def_kind(def_id) {
             DefKind::Fn | DefKind::AssocFn => {
-                if Self::check_safety(tcx, def_id) && self.tcx.visibility(def_id) == Visibility::Public {
+                if Self::check_safety(tcx, def_id)
+                    && self.tcx.visibility(def_id) == Visibility::Public
+                {
                     unsafe_fn.insert(def_id);
-                    self.insert_uig(def_id, self.get_callees(def_id), Self::get_cons(tcx, def_id));
+                    self.insert_uig(
+                        def_id,
+                        self.get_callees(def_id),
+                        Self::get_cons(tcx, def_id),
+                    );
                 }
             }
             DefKind::Mod => {
@@ -143,7 +155,8 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
             let callee_cons = Self::get_cons(self.tcx, *callee);
             pairs.insert((Self::generate_node_ty(self.tcx, *callee), callee_cons));
         }
-        let uig = UigUnit::new_by_pair(Self::generate_node_ty(self.tcx, caller), caller_cons, pairs);
+        let uig =
+            UigUnit::new_by_pair(Self::generate_node_ty(self.tcx, caller), caller_cons, pairs);
         if callee_set.len() > 0 {
             self.uigs.push(uig);
         } else {
@@ -153,7 +166,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
 
     pub fn get_cons(tcx: TyCtxt<'tcx>, def_id: DefId) -> Vec<NodeType> {
         let mut cons = Vec::new();
-        if tcx.def_kind(def_id) == DefKind::Fn || Self::get_type(tcx,def_id) == 0 {
+        if tcx.def_kind(def_id) == DefKind::Fn || Self::get_type(tcx, def_id) == 0 {
             return cons;
         }
         if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
@@ -167,7 +180,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                         for item in tcx.associated_item_def_ids(impl_def_id) {
                             if (tcx.def_kind(item) == DefKind::Fn
                                 || tcx.def_kind(item) == DefKind::AssocFn)
-                                && Self::get_type(tcx,*item) == 0
+                                && Self::get_type(tcx, *item) == 0
                             {
                                 cons.push(Self::generate_node_ty(tcx, *item));
                             }
@@ -205,7 +218,11 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
     }
 
     pub fn generate_node_ty(tcx: TyCtxt<'tcx>, def_id: DefId) -> NodeType {
-        (def_id, Self::check_safety(tcx, def_id), Self::get_type(tcx,def_id))
+        (
+            def_id,
+            Self::check_safety(tcx, def_id),
+            Self::get_type(tcx, def_id),
+        )
     }
 
     pub fn print_hashset<T: std::fmt::Debug>(set: &HashSet<T>) {

--- a/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
+++ b/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
@@ -35,7 +35,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
 
     pub fn get_all_std_unsafe_def_id_by_rustc_extern_crates(
         &mut self,
-        tcx: TyCtxt<'_>,
+        tcx: TyCtxt<'tcx>,
     ) -> HashSet<DefId> {
         let mut visited = HashSet::new();
         let mut unsafe_fn = HashSet::new();
@@ -62,7 +62,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
 
     pub fn get_all_std_unsafe_def_id_by_treat_std_as_local_crate(
         &mut self,
-        tcx: TyCtxt<'_>,
+        tcx: TyCtxt<'tcx>,
     ) -> HashSet<DefId> {
         let mut unsafe_fn = HashSet::new();
         let def_id_sets = tcx.mir_keys(());
@@ -72,9 +72,9 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                 continue;
             }
             if tcx.def_kind(def_id) == DefKind::Fn || tcx.def_kind(def_id) == DefKind::AssocFn {
-                if self.check_safety(def_id) && self.tcx.visibility(def_id) == Visibility::Public {
+                if Self::check_safety(tcx, def_id) && self.tcx.visibility(def_id) == Visibility::Public {
                     unsafe_fn.insert(def_id);
-                    self.insert_uig(def_id, self.get_callees(def_id), self.get_cons(def_id));
+                    self.insert_uig(def_id, self.get_callees(def_id), Self::get_cons(tcx, def_id));
                 }
             }
         }
@@ -83,7 +83,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
 
     pub fn process_def_id(
         &mut self,
-        tcx: TyCtxt<'_>,
+        tcx: TyCtxt<'tcx>,
         def_id: DefId,
         visited: &mut HashSet<DefId>,
         unsafe_fn: &mut HashSet<DefId>,
@@ -93,9 +93,9 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         }
         match tcx.def_kind(def_id) {
             DefKind::Fn | DefKind::AssocFn => {
-                if self.check_safety(def_id) && self.tcx.visibility(def_id) == Visibility::Public {
+                if Self::check_safety(tcx, def_id) && self.tcx.visibility(def_id) == Visibility::Public {
                     unsafe_fn.insert(def_id);
-                    self.insert_uig(def_id, self.get_callees(def_id), self.get_cons(def_id));
+                    self.insert_uig(def_id, self.get_callees(def_id), Self::get_cons(tcx, def_id));
                 }
             }
             DefKind::Mod => {
@@ -140,10 +140,10 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
     ) {
         let mut pairs = HashSet::new();
         for callee in &callee_set {
-            let callee_cons = self.get_cons(*callee);
-            pairs.insert((self.generate_node_ty(*callee), callee_cons));
+            let callee_cons = Self::get_cons(self.tcx, *callee);
+            pairs.insert((Self::generate_node_ty(self.tcx, *callee), callee_cons));
         }
-        let uig = UigUnit::new_by_pair(self.generate_node_ty(caller), caller_cons, pairs);
+        let uig = UigUnit::new_by_pair(Self::generate_node_ty(self.tcx, caller), caller_cons, pairs);
         if callee_set.len() > 0 {
             self.uigs.push(uig);
         } else {
@@ -151,12 +151,11 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         }
     }
 
-    pub fn get_cons(&self, def_id: DefId) -> Vec<NodeType> {
+    pub fn get_cons(tcx: TyCtxt<'tcx>, def_id: DefId) -> Vec<NodeType> {
         let mut cons = Vec::new();
-        if self.tcx.def_kind(def_id) == DefKind::Fn || self.get_type(def_id) == 0 {
+        if tcx.def_kind(def_id) == DefKind::Fn || Self::get_type(tcx,def_id) == 0 {
             return cons;
         }
-        let tcx = self.tcx;
         if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
             if let Some(impl_id) = assoc_item.impl_container(tcx) {
                 // get struct ty
@@ -168,9 +167,9 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                         for item in tcx.associated_item_def_ids(impl_def_id) {
                             if (tcx.def_kind(item) == DefKind::Fn
                                 || tcx.def_kind(item) == DefKind::AssocFn)
-                                && self.get_type(*item) == 0
+                                && Self::get_type(tcx,*item) == 0
                             {
-                                cons.push(self.generate_node_ty(*item));
+                                cons.push(Self::generate_node_ty(tcx, *item));
                             }
                         }
                     }
@@ -192,7 +191,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                             if let ty::FnDef(ref callee_def_id, _) =
                                 func_constant.const_.ty().kind()
                             {
-                                if self.check_safety(*callee_def_id) {
+                                if Self::check_safety(self.tcx, *callee_def_id) {
                                     callees.insert(*callee_def_id);
                                 }
                             }
@@ -205,8 +204,8 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         return callees;
     }
 
-    pub fn generate_node_ty(&self, def_id: DefId) -> NodeType {
-        (def_id, self.check_safety(def_id), self.get_type(def_id))
+    pub fn generate_node_ty(tcx: TyCtxt<'tcx>, def_id: DefId) -> NodeType {
+        (def_id, Self::check_safety(tcx, def_id), Self::get_type(tcx,def_id))
     }
 
     pub fn print_hashset<T: std::fmt::Debug>(set: &HashSet<T>) {

--- a/tests/support/safety_check/audit_case1/Cargo.toml
+++ b/tests/support/safety_check/audit_case1/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "audit_case1"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/tests/support/safety_check/audit_case1/src/main.rs
+++ b/tests/support/safety_check/audit_case1/src/main.rs
@@ -1,0 +1,39 @@
+use std::slice;
+struct St1 { ptr: *mut u8, len: usize }
+struct St2 { ptr: *mut u8, len: usize }
+impl St1 {
+    pub fn st1_from(p: *mut u8, l: usize) -> St1 {
+        St1 { ptr: p, len: l }
+    }
+    
+    pub unsafe fn st1_get(&self) -> &[u8] {
+        slice::from_raw_parts(self.ptr, self.len)
+    }
+}
+impl St2 {
+    pub unsafe fn st2_from(p: *mut u8, l: usize) -> St2 {
+        St2 { ptr: p, len: l }
+    }
+    pub fn st2_get(&self, x: usize) -> u8 {
+        if x < self.len {
+            unsafe { *self.ptr.offset(x as isize) }
+        } else {
+            0
+        }
+    }
+}
+fn f1(p: *mut u8, l: usize) {
+    let s1 = St1::st1_from(p, l); 
+    f2(&s1); 
+}
+fn f2(s1: &St1) {
+    let t1 = unsafe { s1.st1_get() };
+    let s2 = unsafe { St2::st2_from(s1.ptr, s1.len)};
+    let t2 = s2.st2_get(0);
+    assert_eq!(t1[0], t2);
+}
+
+fn main() {
+    let p = &mut 0_u8 as *mut u8;
+    f1(p, 1);
+}


### PR DESCRIPTION
Uphold safety of method to its unsafe constructor simply and add a test case in this situation (see RAP/tests/support/safety_check/audit_case1) .