### PR TITLE
Feat: support alignment analysis of generic type

### DIFF
--- a/rapx/Cargo.toml
+++ b/rapx/Cargo.toml
@@ -37,6 +37,7 @@ walkdir = "2"
 cargo_metadata  = "0.18"
 annotate-snippets = "0.11.4"
 petgraph = "0.7.0"
+if_chain = "1.0"
 
 [features]
 backtraces = ["snafu/backtraces", "snafu/backtraces-impl-backtrace-crate"]

--- a/rapx/src/analysis/senryx/contracts/checker.rs
+++ b/rapx/src/analysis/senryx/contracts/checker.rs
@@ -4,22 +4,22 @@ use core::mem;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-pub trait Checker {
-    fn variable_contracts(&self) -> &HashMap<usize, Vec<Contract>>;
+pub trait Checker<'tcx> {
+    fn variable_contracts(&self) -> &HashMap<usize, Vec<Contract<'tcx>>>;
 }
 
-pub struct SliceFromRawPartsChecker<T> {
-    pub variable_contracts: HashMap<usize, Vec<Contract>>,
+pub struct SliceFromRawPartsChecker<'tcx, T> {
+    pub variable_contracts: HashMap<usize, Vec<Contract<'tcx>>>,
     _marker: PhantomData<T>,
 }
 
-impl<T> Checker for SliceFromRawPartsChecker<T> {
-    fn variable_contracts(&self) -> &HashMap<usize, Vec<Contract>> {
+impl<'tcx, T> Checker<'tcx> for SliceFromRawPartsChecker<'tcx, T> {
+    fn variable_contracts(&self) -> &HashMap<usize, Vec<Contract<'tcx>>> {
         &self.variable_contracts
     }
 }
 
-impl<T> SliceFromRawPartsChecker<T> {
+impl<'tcx, T> SliceFromRawPartsChecker<'tcx, T> {
     pub fn new() -> Self {
         let mut map = HashMap::new();
         map.insert(

--- a/rapx/src/analysis/senryx/contracts/contract.rs
+++ b/rapx/src/analysis/senryx/contracts/contract.rs
@@ -1,32 +1,38 @@
 use super::abstract_state::*;
 use crate::analysis::senryx::contracts::state_lattice::Lattice;
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum Contract {
+#[derive(Debug, PartialEq, Clone)]
+pub enum Contract<'tcx> {
     ValueCheck { op: Op, value: Value },
-    StateCheck { op: Op, state: StateType },
+    StateCheck { op: Op, state: StateType<'tcx> },
 }
 
-pub fn check_contract(contract: Contract, abstate_item: &AbstractStateItem) -> bool {
+pub fn check_contract<'tcx>(
+    contract: &Contract<'tcx>,
+    abstate_item: &AbstractStateItem<'tcx>,
+) -> bool {
     match contract {
         Contract::ValueCheck { op, value } => {
             return handle_value_op(&abstate_item.value, op, value);
         }
-        Contract::StateCheck { op, state } => {
+        Contract::StateCheck { op: _, state } => {
             for ab_state in &abstate_item.state {
-                if check_is_same_state_type(ab_state, &state)
-                    && handle_state_op(*ab_state, op, state)
-                {
-                    return true;
+                if check_is_same_state_type(ab_state, &state) && !ab_state.check() {
+                    return false;
                 }
+                // if check_is_same_state_type(ab_state, &state)
+                //     && handle_state_op(ab_state, op, state)
+                // {
+                //     return true;
+                // }
             }
-            return false;
+            return true;
         }
     }
 }
 
 pub fn check_is_same_state_type(left: &StateType, right: &StateType) -> bool {
-    match (*left, *right) {
+    match (left, right) {
         (StateType::AllocatedState(_), StateType::AllocatedState(_)) => {
             return true;
         }
@@ -39,38 +45,38 @@ pub fn check_is_same_state_type(left: &StateType, right: &StateType) -> bool {
 
 pub fn handle_value_op<T: std::cmp::PartialEq + std::cmp::PartialOrd>(
     left: &(T, T),
-    op: Op,
-    right: T,
+    op: &Op,
+    right: &T,
 ) -> bool {
     match op {
         Op::EQ => {
-            return left.0 == right;
+            return left.0 == *right;
         }
         Op::NE => {
-            return left.0 != right;
+            return left.0 != *right;
         }
         Op::LT => {
-            return left.1 < right;
+            return left.1 < *right;
         }
         Op::GT => {
-            return left.0 > right;
+            return left.0 > *right;
         }
         Op::LE => {
-            return left.1 <= right;
+            return left.1 <= *right;
         }
         Op::GE => {
-            return left.0 >= right;
+            return left.0 >= *right;
         }
     }
 }
 
-pub fn handle_state_op(left: StateType, op: Op, right: StateType) -> bool {
+pub fn handle_state_op<'tcx>(left: &StateType<'tcx>, op: &Op, right: &StateType<'tcx>) -> bool {
     match op {
-        Op::LT => left.less_than(right),
-        Op::LE => left.less_than(right) || left.equal(right),
-        Op::GT => right.less_than(left),
-        Op::GE => right.less_than(left) || right.equal(left),
-        Op::EQ => left.equal(right),
-        Op::NE => !left.equal(right),
+        Op::LT => left.less_than(right.clone()),
+        Op::LE => left.less_than(right.clone()) || left.equal(right.clone()),
+        Op::GT => right.less_than(left.clone()),
+        Op::GE => right.less_than(left.clone()) || right.equal(left.clone()),
+        Op::EQ => left.equal(right.clone()),
+        Op::NE => !left.equal(right.clone()),
     }
 }

--- a/rapx/src/analysis/senryx/generic_check.rs
+++ b/rapx/src/analysis/senryx/generic_check.rs
@@ -1,0 +1,133 @@
+use std::collections::{HashMap, HashSet};
+
+use if_chain::if_chain;
+use rustc_hir::{hir_id::OwnerId, ImplPolarity, ItemId, ItemKind};
+use rustc_middle::ty::{FloatTy, IntTy, ParamEnv, Ty, TyCtxt, TyKind, UintTy};
+// use crate::rap_info;
+
+pub struct GenericChecker<'tcx> {
+    // tcx: TyCtxt<'tcx>,
+    trait_map: HashMap<String, HashSet<Ty<'tcx>>>,
+}
+
+impl<'tcx> GenericChecker<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, p_env: ParamEnv<'tcx>) -> Self {
+        let hir = tcx.hir();
+
+        let mut trait_bnd_map_for_generic: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut satisfied_ty_map_for_generic: HashMap<String, HashSet<Ty<'tcx>>> = HashMap::new();
+
+        for cb in p_env.caller_bounds() {
+            // cb: Binder(TraitPredicate(<Self as trait>, ..)
+            // Focus on the trait bound applied to our generic parameter
+
+            if let Some(trait_pred) = cb.as_trait_clause() {
+                let trait_def_id = trait_pred.def_id();
+                let generic_name = trait_pred.self_ty().skip_binder().to_string();
+                let satisfied_ty_set = satisfied_ty_map_for_generic
+                    .entry(generic_name.clone())
+                    .or_insert_with(|| HashSet::new());
+                let trait_name = tcx.def_path_str(trait_def_id);
+                let trait_bnd_set = trait_bnd_map_for_generic
+                    .entry(generic_name)
+                    .or_insert_with(|| HashSet::new());
+                trait_bnd_set.insert(trait_name.clone());
+
+                // for each implementation
+                for &def_id in hir.trait_impls(trait_def_id) {
+                    // impl_id: LocalDefId
+                    let impl_owner_id = tcx.hir_owner_node(OwnerId { def_id }).def_id();
+
+                    let item = hir.item(ItemId {
+                        owner_id: impl_owner_id,
+                    });
+                    if_chain! {
+                        if let ItemKind::Impl(impl_item) = item.kind;
+                        if impl_item.polarity == ImplPolarity::Positive;
+                        if let Some(binder) = tcx.impl_trait_ref(def_id);
+                        then {
+                            let trait_ref = binder.skip_binder();
+                            let impl_ty = trait_ref.self_ty();
+                            match impl_ty.kind() {
+                                TyKind::Adt(adt_def, _impl_trait_substs) => {
+                                    let adt_did = adt_def.did();
+                                    let adt_ty = tcx.type_of(adt_did).skip_binder();
+                                    // rap_info!("{} is implemented on adt({:?})", trait_name, adt_ty);
+                                    satisfied_ty_set.insert(adt_ty);
+                                },
+                                TyKind::Param(p_ty) => {
+                                    let _param_ty = p_ty.to_ty(tcx);
+                                },
+                                _ => {
+                                    // rap_info!("{} is implemented on {:?}", trait_name, impl_ty);
+                                    satisfied_ty_set.insert(impl_ty);
+                                },
+                            }
+                        }
+                    }
+                }
+
+                // handle known external trait e.g., Pod
+                if trait_name == "bytemuck::Pod" || trait_name == "plain::Plain" {
+                    let ty_bnd = Self::get_satisfied_ty_for_pod(tcx);
+                    satisfied_ty_set.extend(&ty_bnd);
+                    // rap_info!("current trait bound type set: {:?}", satisfied_ty_set);
+                }
+            }
+        }
+
+        // check trait_bnd_set
+        let std_trait_set = HashSet::from([
+            String::from("std::marker::Copy"),
+            String::from("std::clone::Clone"),
+            String::from("std::marker::Sized"),
+        ]);
+        // if all trait_bound is std::marker, then we could assume it to be arbitrary type
+        // to avoid messing up with build type manually
+        // we just clear the satisfied ty set
+        for (key, satisfied_ty_set) in &mut satisfied_ty_map_for_generic {
+            let trait_bnd_set = trait_bnd_map_for_generic
+                .entry(key.clone())
+                .or_insert_with(|| HashSet::new());
+            if trait_bnd_set.is_subset(&std_trait_set) {
+                satisfied_ty_set.clear();
+            }
+        }
+
+        // rap_info!("trait bound type map: {:?}", satisfied_ty_map_for_generic);
+
+        GenericChecker {
+            trait_map: satisfied_ty_map_for_generic,
+        }
+    }
+
+    pub fn get_satisfied_ty_map(&self) -> HashMap<String, HashSet<Ty<'tcx>>> {
+        self.trait_map.clone()
+    }
+
+    fn get_satisfied_ty_for_pod(tcx: TyCtxt<'tcx>) -> HashSet<Ty<'tcx>> {
+        let mut satisfied_ty_set_for_pod: HashSet<Ty<'tcx>> = HashSet::new();
+        // f64, u64, i8, i32, u8, i16, u16, u32, usize, i128, isize, i64, u128, f32
+        let pod_ty = vec![
+            tcx.mk_ty_from_kind(TyKind::Int(IntTy::Isize)),
+            tcx.mk_ty_from_kind(TyKind::Int(IntTy::I8)),
+            tcx.mk_ty_from_kind(TyKind::Int(IntTy::I16)),
+            tcx.mk_ty_from_kind(TyKind::Int(IntTy::I32)),
+            tcx.mk_ty_from_kind(TyKind::Int(IntTy::I64)),
+            tcx.mk_ty_from_kind(TyKind::Int(IntTy::I128)),
+            tcx.mk_ty_from_kind(TyKind::Uint(UintTy::Usize)),
+            tcx.mk_ty_from_kind(TyKind::Uint(UintTy::U8)),
+            tcx.mk_ty_from_kind(TyKind::Uint(UintTy::U16)),
+            tcx.mk_ty_from_kind(TyKind::Uint(UintTy::U32)),
+            tcx.mk_ty_from_kind(TyKind::Uint(UintTy::U64)),
+            tcx.mk_ty_from_kind(TyKind::Uint(UintTy::U128)),
+            tcx.mk_ty_from_kind(TyKind::Float(FloatTy::F32)),
+            tcx.mk_ty_from_kind(TyKind::Float(FloatTy::F64)),
+        ];
+
+        for pt in pod_ty.iter() {
+            satisfied_ty_set_for_pod.insert(*pt);
+        }
+        satisfied_ty_set_for_pod.clone()
+    }
+}

--- a/rapx/src/analysis/senryx/inter_record.rs
+++ b/rapx/src/analysis/senryx/inter_record.rs
@@ -1,24 +1,17 @@
-use lazy_static::lazy_static;
-use rustc_hir::def_id::DefId;
-use std::{collections::HashMap, sync::Mutex};
+use std::collections::HashMap;
 
 use super::contracts::abstract_state::AbstractStateItem;
 
-lazy_static! {
-    pub static ref GLOBAL_INTER_RECORDER: Mutex<HashMap<DefId, InterAnalysisRecord>> =
-        Mutex::new(HashMap::new());
-}
-// static mut GLOBAL_INTER_RECORDER: HashMap<DefId,InterAnalysisRecord> = HashMap::new();
-
-pub struct InterAnalysisRecord {
-    pub pre_analysis_state: HashMap<usize, Option<AbstractStateItem>>,
-    pub post_analysis_state: HashMap<usize, Option<AbstractStateItem>>,
+#[derive(Debug, Clone)]
+pub struct InterAnalysisRecord<'tcx> {
+    pub pre_analysis_state: HashMap<usize, Option<AbstractStateItem<'tcx>>>,
+    pub post_analysis_state: HashMap<usize, Option<AbstractStateItem<'tcx>>>,
 }
 
-impl InterAnalysisRecord {
+impl<'tcx> InterAnalysisRecord<'tcx> {
     pub fn new(
-        pre_analysis_state: HashMap<usize, Option<AbstractStateItem>>,
-        post_analysis_state: HashMap<usize, Option<AbstractStateItem>>,
+        pre_analysis_state: HashMap<usize, Option<AbstractStateItem<'tcx>>>,
+        post_analysis_state: HashMap<usize, Option<AbstractStateItem<'tcx>>>,
     ) -> Self {
         Self {
             pre_analysis_state,
@@ -28,7 +21,7 @@ impl InterAnalysisRecord {
 
     pub fn is_pre_state_same(
         &self,
-        other_pre_state: &HashMap<usize, Option<AbstractStateItem>>,
+        other_pre_state: &HashMap<usize, Option<AbstractStateItem<'tcx>>>,
     ) -> bool {
         self.pre_analysis_state == *other_pre_state
     }

--- a/rapx/src/analysis/senryx/matcher.rs
+++ b/rapx/src/analysis/senryx/matcher.rs
@@ -11,35 +11,35 @@ use super::{
     visitor::CheckResult,
 };
 
-pub fn match_unsafe_api_and_check_contracts<T>(
+pub fn match_unsafe_api_and_check_contracts<'tcx, T>(
     func_name: &str,
     args: &Box<[Spanned<Operand>]>,
-    abstate: &AbstractState,
+    abstate: &AbstractState<'tcx>,
     span: Span,
     _ty: T,
-) -> Option<CheckResult> {
-    let base_func_name = func_name.split::<&str>("<").next().unwrap_or(func_name);
+) -> Option<CheckResult<'tcx>> {
+    // let base_func_name = func_name.split::<&str>("<").next().unwrap_or(func_name);
     // println!("base name ---- {:?}",base_func_name);
-    let checker: Option<Box<dyn Checker>> = match base_func_name {
-        "std::slice::from_raw_parts::" | "std::slice::from_raw_parts_mut::" => {
+    let checker: Option<Box<dyn Checker>> = match func_name {
+        "core::slice::raw::from_raw_parts" | "core::slice::raw::from_raw_parts_mut" => {
             Some(Box::new(SliceFromRawPartsChecker::<T>::new()))
         }
         _ => None,
     };
 
     if let Some(c) = checker {
-        return Some(process_checker(&*c, args, abstate, base_func_name, span));
+        return Some(process_checker(&*c, args, abstate, func_name, span));
     }
     None
 }
 
-fn process_checker(
-    checker: &dyn Checker,
+fn process_checker<'tcx>(
+    checker: &dyn Checker<'tcx>,
     args: &Box<[Spanned<Operand>]>,
-    abstate: &AbstractState,
+    abstate: &AbstractState<'tcx>,
     func_name: &str,
     span: Span,
-) -> CheckResult {
+) -> CheckResult<'tcx> {
     let mut check_result = CheckResult::new(func_name, span);
     for (idx, contracts_vec) in checker.variable_contracts().iter() {
         for contract in contracts_vec {
@@ -48,10 +48,10 @@ fn process_checker(
                 continue;
             }
             if let Some(abstate_item) = abstate.state_map.get(&arg_place) {
-                if !check_contract(*contract, &abstate_item.clone().unwrap()) {
-                    check_result.failed_contracts.push((*idx, *contract));
+                if !check_contract(contract, &abstate_item.clone().unwrap()) {
+                    check_result.failed_contracts.push((*idx, contract.clone()));
                 } else {
-                    check_result.passed_contracts.push((*idx, *contract));
+                    check_result.passed_contracts.push((*idx, contract.clone()));
                 }
             }
         }

--- a/rapx/src/analysis/unsafety_isolation/data/std_sps.json
+++ b/rapx/src/analysis/unsafety_isolation/data/std_sps.json
@@ -7,14 +7,14 @@
     },
     "core::alloc::global::GlobalAlloc::realloc": {
       "sp": [
-        "AllocatorConsistency",
+        "Allocated",
         "LayoutConsistency",
         "ValidInt"
       ]
     },
     "core::alloc::global::GlobalAlloc::dealloc": {
       "sp": [
-        "AllocatorConsistency",
+        "Allocated",
         "LayoutConsistency"
       ]
     },
@@ -37,54 +37,54 @@
       },
     "core::alloc::Allocator::grow": {
       "sp": [
-        "AllocatorConsistency",
+        "Allocated",
         "LayoutConsistency",
         "ValidInt"
       ]
     },
     "core::alloc::Allocator::grow_zeroed": {
       "sp": [
-        "AllocatorConsistency",
+        "Allocated",
         "LayoutConsistency",
         "ValidInt"
       ]
     },
     "core::alloc::Allocator::shrink": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "core::alloc::Allocator::deallocate": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency"
         ]
     },
     "core::alloc::deallocate": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency"
         ]
     },
     "core::alloc::grow": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "core::alloc::grow_zeroed": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "core::alloc::shrink": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
@@ -187,7 +187,9 @@
     "core::future::async_drop::async_drop_in_place": {
         "sp": [
             "ValidPtr",
-            "Aligned"
+            "Aligned",
+            "NonNull",
+            "Dangling"
         ]
     },
     "core::iter::range::forward_unchecked": {
@@ -212,7 +214,7 @@
     },
     "core::mem::manually_drop::take": {
         "sp": [
-            "NonOwned"
+            "Ownning"
         ]
     },
     "core::mem::manually_drop::drop": {
@@ -439,7 +441,7 @@
     },
     "core::intrinsics::ptr_offset_from": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
@@ -479,58 +481,58 @@
     },
     "core::ptr::non_null::offset": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::non_null::add": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::non_null::byte_offset": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::non_null::byte_add": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::non_null::byte_sub": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::non_null::offset_from": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::non_null::byte_offset_from": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::non_null::sub_ptr": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::non_null::sub": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
@@ -689,65 +691,65 @@
     },
     "core::ptr::const_ptr::offset": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::const_ptr::add": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::const_ptr::sub": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::const_ptr::byte_offset": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::const_ptr::offset_from": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::const_ptr::byte_offset_from": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::const_ptr::non_null::sub_ptr": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::const_ptr::sub_ptr": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::const_ptr::byte_add": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::const_ptr::byte_sub": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
@@ -833,7 +835,7 @@
     },
     "core::ptr::mut_ptr::offset": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
@@ -855,52 +857,52 @@
     },
     "core::ptr::mut_ptr::add": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::mut_ptr::sub": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::mut_ptr::byte_offset": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::mut_ptr::offset_from": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::mut_ptr::byte_offset_from": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::mut_ptr::sub_ptr": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt",
             "!ZST"
         ]
     },
     "core::ptr::mut_ptr::byte_add": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
     "core::ptr::mut_ptr::byte_sub": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
@@ -908,6 +910,7 @@
         "sp": [
             "ValidPtr",
             "Aligned",
+            "CopyTrait",
             "Init"
         ]
     },
@@ -915,12 +918,14 @@
         "sp": [
             "ValidPtr",
             "Aligned",
+            "CopyTrait",
             "Init"
         ]
     },
     "core::ptr::mut_ptr::read_unaligned": {
         "sp": [
             "ValidPtr",
+            "CopyTrait",
             "Init"
         ]
     },
@@ -1118,7 +1123,7 @@
     },
     "core::ptr::offset": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
@@ -1153,13 +1158,13 @@
     "core::slice::index::SliceIndex::get_unchecked": {
         "sp": [
             "InBounded",
-            "!Dangling"
+            "Dangling"
         ]
     },
     "core::slice::index::SliceIndex::get_unchecked_mut": {
         "sp": [
             "InBounded",
-            "!Dangling"
+            "Dangling"
         ]
     },
     "core::slice::get_unchecked_mut": {
@@ -1236,13 +1241,13 @@
     },
     "core::slice::index::get_unchecked": {
         "sp": [
-            "!Dangling",
+            "Dangling",
             "InBounded"
         ]
     },
     "core::slice::index::get_unchecked_mut": {
         "sp": [
-            "!Dangling",
+            "Dangling",
             "InBounded"
         ]
     },
@@ -1254,7 +1259,9 @@
             "Lifetime",
             "Alias",
             "ValidInt",
-            "Aligned"
+            "Aligned",
+            "InBounded",
+            "!ZST"
         ]
     },
     "core::slice::raw::from_mut_ptr_range": {
@@ -1351,52 +1358,57 @@
             "Init"
         ]
     },
+    "core::io::borrowed_buf::as_mut": {
+        "sp": [
+            "Init"
+        ]
+    },
     "core::task::wake::from_raw": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
 
     "alloc::vec::from_raw_parts": {
         "sp": [
-            "AllocatorConsistency",
-            "Aligned",
             "Allocated",
+            "Aligned",
+            "InBounded",
             "ValidInt",
             "LayoutConsistency"
         ]
     },
     "alloc::vec::from_parts": {
         "sp": [
-            "AllocatorConsistency",
-            "Aligned",
             "Allocated",
+            "Aligned",
+            "InBounded",
             "ValidInt",
             "LayoutConsistency"
         ]
     },
     "alloc::vec::from_raw_parts_in": {
         "sp": [
-            "AllocatorConsistency",
-            "Aligned",
             "Allocated",
+            "Aligned",
+            "InBounded",
             "ValidInt",
             "LayoutConsistency"
         ]
     },
     "alloc::vec::from_parts_in": {
         "sp": [
-            "AllocatorConsistency",
-            "Aligned",
             "Allocated",
+            "Aligned",
+            "InBounded",
             "ValidInt",
             "LayoutConsistency"
         ]
     },
     "alloc::vec::set_len": {
         "sp": [
-            "Allocated",
+            "InBounded",
             "ValidInt"
         ]
     },
@@ -1408,13 +1420,13 @@
     },
     "alloc::alloc::dealloc": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency"
         ]
     },
     "alloc::alloc::realloc": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
@@ -1426,27 +1438,27 @@
     },
     "alloc::alloc::deallocate": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency"
         ]
     },
     "alloc::alloc::grow": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "alloc::alloc::grow_zeroed": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "alloc::alloc::shrink": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
@@ -1458,25 +1470,25 @@
     },
     "alloc::boxed::from_raw": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Ownning"
         ]
     },
     "alloc::boxed::from_non_null": {
         "sp": [
-            "AllocatorConsistency",
-            "Alias"
+            "Allocated",
+            "Ownning"
         ]
     },
     "alloc::boxed::from_raw_in": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Ownning"
         ]
     },
     "alloc::boxed::from_non_null_in": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Ownning"
         ]
     },
@@ -1516,7 +1528,7 @@
     },
     "alloc::ffi::c_str::from_raw": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Ownning"
         ]
     },
@@ -1532,38 +1544,39 @@
     },
     "alloc::rc::from_raw": {
         "sp": [
-            "AllocatorConsistency",
-            "Aligned"
+            "Allocated",
+            "Aligned",
+            "Ownning"
         ]
     },
     "alloc::rc::increment_strong_count": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
     "alloc::rc::decrement_strong_count": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
     "alloc::rc::from_raw_in": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Aligned",
             "Ownning"
         ]
     },
     "alloc::rc::increment_strong_count_in": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
     "alloc::rc::decrement_strong_count_in": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
@@ -1597,7 +1610,7 @@
     },
     "alloc::string::from_raw_parts": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Aligned",
             "ValidInt",
             "ValidString"
@@ -1621,37 +1634,38 @@
     },
     "alloc::sync::from_raw": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Aligned"
         ]
     },
     "alloc::sync::increment_strong_count": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
     "alloc::sync::decrement_strong_count": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
     "alloc::sync::from_raw_in": {
         "sp": [
-            "AllocatorConsistency",
-            "Aligned"
+            "Allocated",
+            "Aligned",
+            "Ownning"
         ]
     },
     "alloc::sync::increment_strong_count_in": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
     "alloc::sync::decrement_strong_count_in": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "Dangling"
         ]
     },
@@ -1663,7 +1677,7 @@
     "std::thread::from_raw": {
         "sp": [
             "Ownning",
-            "AllocatorConsistency"
+            "Allocated"
         ]
     },
     "std::collections::hash::map::get_many_unchecked_mut": {
@@ -1802,54 +1816,54 @@
     },
     "std::alloc::System::deallocate": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency"
         ]
     },
     "std::alloc::System::grow": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "std::alloc::System::grow_zeroed": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "std::alloc::System::shrink": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "std::alloc::deallocate": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency"
         ]
     },
     "std::alloc::grow": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "std::alloc::grow_zeroed": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
     },
     "std::alloc::shrink": {
         "sp": [
-            "AllocatorConsistency",
+            "Allocated",
             "LayoutConsistency",
             "ValidInt"
         ]
@@ -1870,6 +1884,81 @@
         "sp": [
             "Lifetime",
             "Init",
+            ""
+        ]
+    },
+    "core::intrinsics::const_allocate": {
+        "sp": [
+            "ValidInt"
+        ]
+    },
+    "core::intrinsics::assume": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::intrinsics::drop_in_place": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::intrinsics::const_deallocate": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::intrinsics::vtable_size": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::intrinsics::vtable_align": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::intrinsics::pref_align_of": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::intrinsics::size_of_val": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::intrinsics::min_align_of_val": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::ffi::va_list::arg": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::ffi::va_list::with_copy": {
+        "sp": [
+            ""
+        ]
+    },
+    "core::task::wake::new": {
+        "sp": [
+            ""
+        ]
+    },
+    "alloc::collections::btree::set::with_mutable_key": {
+        "sp": [
+            ""
+        ]
+    },
+    "alloc::sync::assume_init": {
+        "sp": [
+            "Init"
+        ]
+    },
+    "std::sys::os_str::bytes::from_encoded_bytes_unchecked": {
+        "sp": [
             ""
         ]
     }

--- a/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
+++ b/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
@@ -1,12 +1,10 @@
+use crate::analysis::utils::fn_info::*;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_hir::def_id::CRATE_DEF_INDEX;
 use rustc_middle::ty::Visibility;
-use rustc_middle::{
-    mir::{Operand, TerminatorKind},
-    ty,
-    ty::TyCtxt,
-};
+use rustc_middle::{ty, ty::TyCtxt};
+use std::collections::HashMap;
 use std::collections::HashSet;
 // use crate::analysis::unsafety_isolation::draw_dot::render_dot_graphs;
 
@@ -18,6 +16,7 @@ use super::{
 impl<'tcx> UnsafetyIsolationCheck<'tcx> {
     pub fn handle_std_unsafe(&mut self) {
         self.get_all_std_unsafe_def_id_by_treat_std_as_local_crate(self.tcx);
+        // self.get_units_data(self.tcx);
         let mut dot_strs = Vec::new();
         for uig in &self.uigs {
             let dot_str = uig.generate_dot_str();
@@ -26,7 +25,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         }
         for uig in &self.single {
             let dot_str = uig.generate_dot_str();
-            // uig.compare_labels();
+            // uig.compare_labels(self.tcx);
             dot_strs.push(dot_str);
         }
         // println!("single {:?}",self.single.len());
@@ -66,28 +65,175 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
     ) -> HashSet<DefId> {
         let mut unsafe_fn = HashSet::new();
         let def_id_sets = tcx.mir_keys(());
+        let mut sp_count_map: HashMap<String, usize> = HashMap::new();
+
         for local_def_id in def_id_sets {
             let def_id = local_def_id.to_def_id();
             if Self::filter_mir(def_id) {
                 continue;
             }
             if tcx.def_kind(def_id) == DefKind::Fn || tcx.def_kind(def_id) == DefKind::AssocFn {
-                if Self::check_safety(tcx, def_id)
-                    && self.tcx.visibility(def_id) == Visibility::Public
-                {
-                    // if UigUnit::get_sp(tcx, def_id).len() == 0 {
-                    //     println!("name : {:?}", UigUnit::get_cleaned_def_path_name(tcx, def_id));
-                    // }
-                    unsafe_fn.insert(def_id);
-                    self.insert_uig(
-                        def_id,
-                        self.get_callees(def_id),
-                        Self::get_cons(tcx, def_id),
-                    );
+                // if Self::check_safety(tcx, def_id)
+                //     && Self::check_visibility(tcx, def_id)
+                if check_visibility(tcx, def_id) {
+                    if check_safety(tcx, def_id) {
+                        let sp_set = get_sp(tcx, def_id);
+                        if sp_set.len() != 0 {
+                            unsafe_fn.insert(def_id);
+                            // println!("unsafe fn : {:?}", UigUnit::get_cleaned_def_path_name(self.tcx, def_id));
+                        }
+                        for sp in sp_set {
+                            *sp_count_map.entry(sp).or_insert(0) += 1;
+                        }
+                    }
+                    self.insert_uig(def_id, get_callees(tcx, def_id), get_cons(tcx, def_id));
                 }
             }
         }
+        self.analyze_struct();
+        // self.analyze_uig();
+        // for (sp, count) in &sp_count_map {
+        //     println!("SP: {}, Count: {}", sp, count);
+        // }
+        // println!("uig and single len : {:?} and {:?}", self.uigs.len(), self.single.len());
+        // println!("unsafe fn len {}", unsafe_fn.len());
         unsafe_fn
+    }
+
+    pub fn analyze_uig(&self) {
+        let mut pro1 = Vec::new();
+        let mut enc1 = Vec::new();
+        for uig in &self.uigs {
+            if uig.caller.1 != true && uig.caller.2 == 2 {
+                enc1.push(uig.clone());
+            } else if uig.caller.1 == true && uig.caller.2 == 2 {
+                pro1.push(uig.clone());
+            }
+        }
+
+        let mut no_unsafe_con = Vec::new();
+        for uig in pro1 {
+            let mut flag = 0;
+            for con in &uig.caller_cons {
+                if con.1 == true {
+                    flag = 1;
+                }
+            }
+            if flag == 0 {
+                no_unsafe_con.push(uig.clone());
+            }
+        }
+    }
+
+    pub fn analyze_struct(&self) {
+        let mut cache = HashSet::new();
+        for uig in &self.uigs {
+            self.get_struct(uig.caller.0, &mut cache);
+        }
+        for uig in &self.single {
+            self.get_struct(uig.caller.0, &mut cache);
+        }
+    }
+
+    pub fn get_struct(&self, def_id: DefId, cache: &mut HashSet<DefId>) {
+        let tcx = self.tcx;
+        let mut safe_constructors = Vec::new();
+        let mut unsafe_constructors = Vec::new();
+        let mut unsafe_methods = Vec::new();
+        let mut safe_methods = Vec::new();
+        let mut struct_name = "".to_string();
+        if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
+            if let Some(impl_id) = assoc_item.impl_container(tcx) {
+                // get struct ty
+                let ty = tcx.type_of(impl_id).skip_binder();
+                if let Some(adt_def) = ty.ty_adt_def() {
+                    let adt_def_id = adt_def.did();
+                    struct_name = get_cleaned_def_path_name(tcx, adt_def_id);
+                    if !cache.insert(adt_def_id) {
+                        return;
+                    }
+                    let impl_vec = get_impls_for_struct(self.tcx, adt_def_id);
+                    for impl_id in impl_vec {
+                        let associated_items = tcx.associated_items(impl_id);
+                        for item in associated_items.in_definition_order() {
+                            if let ty::AssocKind::Fn = item.kind {
+                                let item_def_id = item.def_id;
+                                if get_type(self.tcx, item_def_id) == 0
+                                    && check_safety(self.tcx, item_def_id) == true
+                                {
+                                    unsafe_constructors.push(item_def_id);
+                                }
+                                if get_type(self.tcx, item_def_id) == 0
+                                    && check_safety(self.tcx, item_def_id) == false
+                                {
+                                    safe_constructors.push(item_def_id);
+                                }
+                                if get_type(self.tcx, item_def_id) == 1
+                                    && check_safety(self.tcx, item_def_id) == true
+                                {
+                                    unsafe_methods.push(item_def_id);
+                                }
+                                if get_type(self.tcx, item_def_id) == 1
+                                    && check_safety(self.tcx, item_def_id) == false
+                                {
+                                    if get_callees(tcx, item_def_id).len() != 0 {
+                                        safe_methods.push(item_def_id);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if struct_name == "".to_string()
+            || (unsafe_constructors.len() == 0
+                && unsafe_methods.len() == 0
+                && safe_methods.len() == 0)
+        {
+            return;
+        }
+        println!("Struct:{:?}", struct_name);
+        println!("Safe Cons: ");
+        for safe_cons in safe_constructors {
+            println!(" {:?}", get_cleaned_def_path_name(tcx, safe_cons));
+        }
+        println!("Unsafe Cons: ");
+        for unsafe_cons in unsafe_constructors {
+            println!(" {:?}", get_cleaned_def_path_name(tcx, unsafe_cons));
+        }
+        println!("Unsafe Methods: ");
+        for method in unsafe_methods {
+            println!(" {:?}", get_cleaned_def_path_name(tcx, method));
+        }
+        println!("Safe Methods with unsafe callee: ");
+        for method in safe_methods {
+            println!(" {:?}", get_cleaned_def_path_name(tcx, method));
+        }
+    }
+
+    pub fn get_units_data(&mut self, tcx: TyCtxt<'tcx>) {
+        // [uf/um, sf-uf, sf-um, uf-uf, uf-um, um(sf)-uf, um(uf)-uf, um(sf)-um, um(uf)-um, sm(sf)-uf, sm(uf)-uf, sm(sf)-um, sm(uf)-um]
+        let mut basic_units_data = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let def_id_sets = tcx.mir_keys(());
+        for local_def_id in def_id_sets {
+            let def_id = local_def_id.to_def_id();
+            if Self::filter_mir(def_id) {
+                continue;
+            }
+            if tcx.def_kind(def_id) == DefKind::Fn || tcx.def_kind(def_id) == DefKind::AssocFn {
+                if check_visibility(tcx, def_id) {
+                    self.insert_uig(def_id, get_callees(tcx, def_id), get_cons(tcx, def_id));
+                }
+            }
+        }
+        for uig in &self.uigs {
+            uig.count_basic_units(&mut basic_units_data);
+        }
+        for single in &self.single {
+            single.count_basic_units(&mut basic_units_data);
+        }
+        println!("basic_units_data : {:?}", basic_units_data);
     }
 
     pub fn process_def_id(
@@ -102,15 +248,9 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         }
         match tcx.def_kind(def_id) {
             DefKind::Fn | DefKind::AssocFn => {
-                if Self::check_safety(tcx, def_id)
-                    && self.tcx.visibility(def_id) == Visibility::Public
-                {
+                if check_safety(tcx, def_id) && self.tcx.visibility(def_id) == Visibility::Public {
                     unsafe_fn.insert(def_id);
-                    self.insert_uig(
-                        def_id,
-                        self.get_callees(def_id),
-                        Self::get_cons(tcx, def_id),
-                    );
+                    self.insert_uig(def_id, get_callees(tcx, def_id), get_cons(tcx, def_id));
                 }
             }
             DefKind::Mod => {
@@ -170,83 +310,17 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
     ) {
         let mut pairs = HashSet::new();
         for callee in &callee_set {
-            let callee_cons = Self::get_cons(self.tcx, *callee);
-            pairs.insert((Self::generate_node_ty(self.tcx, *callee), callee_cons));
+            let callee_cons = get_cons(self.tcx, *callee);
+            pairs.insert((generate_node_ty(self.tcx, *callee), callee_cons));
         }
-        let uig =
-            UigUnit::new_by_pair(Self::generate_node_ty(self.tcx, caller), caller_cons, pairs);
+        if !check_safety(self.tcx, caller) && callee_set.len() == 0 {
+            return;
+        }
+        let uig = UigUnit::new_by_pair(generate_node_ty(self.tcx, caller), caller_cons, pairs);
         if callee_set.len() > 0 {
             self.uigs.push(uig);
         } else {
             self.single.push(uig);
         }
-    }
-
-    pub fn get_cons(tcx: TyCtxt<'tcx>, def_id: DefId) -> Vec<NodeType> {
-        let mut cons = Vec::new();
-        if tcx.def_kind(def_id) == DefKind::Fn || Self::get_type(tcx, def_id) == 0 {
-            return cons;
-        }
-        if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
-            if let Some(impl_id) = assoc_item.impl_container(tcx) {
-                // get struct ty
-                let ty = tcx.type_of(impl_id).skip_binder();
-                if let Some(adt_def) = ty.ty_adt_def() {
-                    let adt_def_id = adt_def.did();
-                    let impls = tcx.inherent_impls(adt_def_id);
-                    for impl_def_id in impls {
-                        for item in tcx.associated_item_def_ids(impl_def_id) {
-                            if (tcx.def_kind(item) == DefKind::Fn
-                                || tcx.def_kind(item) == DefKind::AssocFn)
-                                && Self::get_type(tcx, *item) == 0
-                            {
-                                cons.push(Self::generate_node_ty(tcx, *item));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        cons
-    }
-
-    pub fn get_callees(&self, def_id: DefId) -> HashSet<DefId> {
-        let mut callees = HashSet::new();
-        let tcx = self.tcx;
-        if tcx.is_mir_available(def_id) {
-            let body = tcx.optimized_mir(def_id);
-            for bb in body.basic_blocks.iter() {
-                match &bb.terminator().kind {
-                    TerminatorKind::Call { func, .. } => {
-                        if let Operand::Constant(func_constant) = func {
-                            if let ty::FnDef(ref callee_def_id, _) =
-                                func_constant.const_.ty().kind()
-                            {
-                                if Self::check_safety(self.tcx, *callee_def_id) {
-                                    callees.insert(*callee_def_id);
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-        return callees;
-    }
-
-    pub fn generate_node_ty(tcx: TyCtxt<'tcx>, def_id: DefId) -> NodeType {
-        (
-            def_id,
-            Self::check_safety(tcx, def_id),
-            Self::get_type(tcx, def_id),
-        )
-    }
-
-    pub fn print_hashset<T: std::fmt::Debug>(set: &HashSet<T>) {
-        for item in set {
-            println!("{:?}", item);
-        }
-        println!("---------------");
     }
 }

--- a/rapx/src/analysis/utils.rs
+++ b/rapx/src/analysis/utils.rs
@@ -1,3 +1,4 @@
 pub mod def_path;
+pub mod fn_info;
 pub mod intrinsic_id;
 pub mod show_mir;

--- a/rapx/src/analysis/utils/fn_info.rs
+++ b/rapx/src/analysis/utils/fn_info.rs
@@ -1,0 +1,264 @@
+use crate::analysis::unsafety_isolation::generate_dot::NodeType;
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::DefId;
+use rustc_middle::ty::Ty;
+use rustc_middle::ty::TyCtxt;
+use rustc_middle::{
+    mir::{Operand, TerminatorKind},
+    ty,
+};
+use rustc_span::def_id::LocalDefId;
+use std::collections::HashSet;
+
+pub fn generate_node_ty(tcx: TyCtxt<'_>, def_id: DefId) -> NodeType {
+    (def_id, check_safety(tcx, def_id), get_type(tcx, def_id))
+}
+
+pub fn check_visibility(tcx: TyCtxt<'_>, func_defid: DefId) -> bool {
+    if !tcx.visibility(func_defid).is_public() {
+        return false;
+    }
+    // if func_defid.is_local() {
+    //     if let Some(local_defid) = func_defid.as_local() {
+    //         let module_moddefid = tcx.parent_module_from_def_id(local_defid);
+    //         let module_defid = module_moddefid.to_def_id();
+    //         if !tcx.visibility(module_defid).is_public() {
+    //             // println!("module def id {:?}",UigUnit::get_cleaned_def_path_name(tcx, module_defid));
+    //             return Self::is_re_exported(tcx, func_defid, module_moddefid.to_local_def_id());
+    //         }
+    //     }
+    // }
+    true
+}
+
+pub fn is_re_exported(tcx: TyCtxt<'_>, target_defid: DefId, module_defid: LocalDefId) -> bool {
+    for child in tcx.module_children_local(module_defid) {
+        if child.vis.is_public() {
+            if let Some(def_id) = child.res.opt_def_id() {
+                if def_id == target_defid {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn print_hashset<T: std::fmt::Debug>(set: &HashSet<T>) {
+    for item in set {
+        println!("{:?}", item);
+    }
+    println!("---------------");
+}
+
+pub fn get_cleaned_def_path_name(tcx: TyCtxt<'_>, def_id: DefId) -> String {
+    let def_id_str = format!("{:?}", def_id);
+    let mut parts: Vec<&str> = def_id_str
+        .split("::")
+        // .filter(|part| !part.contains("{")) // 去除包含 "{" 的部分
+        .collect();
+
+    let mut remove_first = false;
+    if let Some(first_part) = parts.get_mut(0) {
+        if first_part.contains("core") {
+            *first_part = "core";
+        } else if first_part.contains("std") {
+            *first_part = "std";
+        } else if first_part.contains("alloc") {
+            *first_part = "alloc";
+        } else {
+            remove_first = true;
+        }
+    }
+    if remove_first && !parts.is_empty() {
+        parts.remove(0);
+    }
+
+    let new_parts: Vec<String> = parts
+        .into_iter()
+        .filter_map(|s| {
+            if s.contains("{") {
+                if remove_first {
+                    match get_struct_name(tcx, def_id) {
+                        Some(name) => Some(name),
+                        None => None,
+                    }
+                } else {
+                    None
+                }
+            } else {
+                Some(s.to_string())
+            }
+        })
+        .collect();
+
+    let mut cleaned_path = new_parts.join("::");
+    cleaned_path = cleaned_path.trim_end_matches(')').to_string();
+    cleaned_path
+}
+
+pub fn get_sp_json() -> serde_json::Value {
+    let json_data: serde_json::Value =
+        serde_json::from_str(include_str!("../unsafety_isolation/data/std_sps.json"))
+            .expect("Unable to parse JSON");
+    json_data
+}
+
+pub fn get_sp(tcx: TyCtxt<'_>, def_id: DefId) -> HashSet<String> {
+    let cleaned_path_name = get_cleaned_def_path_name(tcx, def_id);
+    let json_data: serde_json::Value = get_sp_json();
+
+    if let Some(function_info) = json_data.get(&cleaned_path_name) {
+        if let Some(sp_list) = function_info.get("sp") {
+            let mut result = HashSet::new();
+            if let Some(sp_array) = sp_list.as_array() {
+                for sp in sp_array {
+                    if let Some(sp_name) = sp.as_str() {
+                        result.insert(sp_name.to_string());
+                    }
+                }
+            }
+            return result;
+        }
+    }
+    HashSet::new()
+}
+
+pub fn get_struct_name(tcx: TyCtxt<'_>, def_id: DefId) -> Option<String> {
+    if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
+        if let Some(impl_id) = assoc_item.impl_container(tcx) {
+            let ty = tcx.type_of(impl_id).skip_binder();
+            let type_name = ty.to_string();
+            let struct_name = type_name
+                .split('<')
+                .next()
+                .unwrap_or("")
+                .split("::")
+                .last()
+                .unwrap_or("")
+                .to_string();
+
+            return Some(struct_name);
+        }
+    }
+    None
+}
+
+pub fn check_safety(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+    let poly_fn_sig = tcx.fn_sig(def_id);
+    let fn_sig = poly_fn_sig.skip_binder();
+    fn_sig.safety() == rustc_hir::Safety::Unsafe
+}
+
+//retval: 0-constructor, 1-method, 2-function
+pub fn get_type(tcx: TyCtxt<'_>, def_id: DefId) -> usize {
+    let mut node_type = 2;
+    if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
+        if assoc_item.fn_has_self_parameter {
+            node_type = 1;
+        } else {
+            let fn_sig = tcx.fn_sig(def_id).skip_binder();
+            let output = fn_sig.output().skip_binder();
+            // return type is 'Self'
+            if output.is_param(0) {
+                node_type = 0;
+            }
+            // return type is struct's name
+            if let Some(impl_id) = assoc_item.impl_container(tcx) {
+                let ty = tcx.type_of(impl_id).skip_binder();
+                if output == ty {
+                    node_type = 0;
+                }
+            }
+        }
+    }
+    return node_type;
+}
+
+pub fn get_cons(tcx: TyCtxt<'_>, def_id: DefId) -> Vec<NodeType> {
+    let mut cons = Vec::new();
+    if tcx.def_kind(def_id) == DefKind::Fn || get_type(tcx, def_id) == 0 {
+        return cons;
+    }
+    if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
+        if let Some(impl_id) = assoc_item.impl_container(tcx) {
+            // get struct ty
+            let ty = tcx.type_of(impl_id).skip_binder();
+            if let Some(adt_def) = ty.ty_adt_def() {
+                let adt_def_id = adt_def.did();
+                let impls = tcx.inherent_impls(adt_def_id);
+                for impl_def_id in impls {
+                    for item in tcx.associated_item_def_ids(impl_def_id) {
+                        if (tcx.def_kind(item) == DefKind::Fn
+                            || tcx.def_kind(item) == DefKind::AssocFn)
+                            && get_type(tcx, *item) == 0
+                            && check_visibility(tcx, *item)
+                        {
+                            cons.push(generate_node_ty(tcx, *item));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    cons
+}
+
+pub fn get_callees(tcx: TyCtxt<'_>, def_id: DefId) -> HashSet<DefId> {
+    let mut callees = HashSet::new();
+    if tcx.is_mir_available(def_id) {
+        let body = tcx.optimized_mir(def_id);
+        for bb in body.basic_blocks.iter() {
+            match &bb.terminator().kind {
+                TerminatorKind::Call { func, .. } => {
+                    if let Operand::Constant(func_constant) = func {
+                        if let ty::FnDef(ref callee_def_id, _) = func_constant.const_.ty().kind() {
+                            if check_safety(tcx, *callee_def_id)
+                                && check_visibility(tcx, *callee_def_id)
+                            {
+                                let sp_set = get_sp(tcx, *callee_def_id);
+                                if sp_set.len() != 0 {
+                                    callees.insert(*callee_def_id);
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    return callees;
+}
+
+pub fn get_impls_for_struct(tcx: TyCtxt<'_>, struct_def_id: DefId) -> Vec<DefId> {
+    let mut impls = Vec::new();
+    for item_id in tcx.hir().items() {
+        let item = tcx.hir().item(item_id);
+        if let rustc_hir::ItemKind::Impl(ref impl_item) = item.kind {
+            if let rustc_hir::TyKind::Path(ref qpath) = impl_item.self_ty.kind {
+                if let rustc_hir::QPath::Resolved(_, ref path) = qpath {
+                    if let rustc_hir::def::Res::Def(_, ref def_id) = path.res {
+                        if *def_id == struct_def_id {
+                            impls.push(item.owner_id.to_def_id());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    impls
+}
+
+// get the pointee or wrapped type
+pub fn get_pointee(matched_ty: Ty<'_>) -> Ty<'_> {
+    // progress_info!("get_pointee: > {:?} as type: {:?}", matched_ty, matched_ty.kind());
+    let pointee = if let ty::RawPtr(ty_mut, _) = matched_ty.kind() {
+        get_pointee(*ty_mut)
+    } else if let ty::Ref(_, referred_ty, _) = matched_ty.kind() {
+        get_pointee(*referred_ty)
+    } else {
+        matched_ty
+    };
+    pointee
+}

--- a/rapx/src/lib.rs
+++ b/rapx/src/lib.rs
@@ -25,7 +25,7 @@ use analysis::core::dataflow::DataFlow;
 use analysis::opt::Opt;
 use analysis::rcanary::rCanary;
 use analysis::safedrop::SafeDrop;
-use analysis::senryx::SenryxCheck;
+use analysis::senryx::{CheckLevel, SenryxCheck};
 use analysis::unsafety_isolation::{UigInstruction, UnsafetyIsolationCheck};
 use analysis::utils::show_mir::ShowMir;
 use rustc_data_structures::sync::Lrc;
@@ -241,7 +241,8 @@ pub fn start_analyzer(tcx: TyCtxt, callback: RapCallback) {
     }
 
     if callback.is_annotation_enabled() {
-        SenryxCheck::new(tcx, 2).start();
+        let check_level = CheckLevel::High;
+        SenryxCheck::new(tcx, 2).start(check_level);
     }
 
     if callback.is_show_mir_enabled() {

--- a/tests/support/safety_check/slice_from_raw_parts/Cargo.toml
+++ b/tests/support/safety_check/slice_from_raw_parts/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "audit_case1"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/tests/support/safety_check/slice_from_raw_parts/src/main.rs
+++ b/tests/support/safety_check/slice_from_raw_parts/src/main.rs
@@ -1,0 +1,147 @@
+// use std::ptr;
+use std::slice;
+// use std::mem::MaybeUninit;
+
+// struct MySliceWrapperTest<T> {
+//     data: *const T, 
+//     len: usize,     
+// }
+
+// impl<T> MySliceWrapperTest<T> {
+//     fn new() -> Self {
+//         let uninit_data = MaybeUninit::<[T; 10]>::uninit();
+//         let data = uninit_data.as_ptr() as *const T;
+//         MySliceWrapperTest { data, len: 10 }
+//     }
+
+//     fn get_slice(&self, offset: usize, length: usize) -> &[T] {
+//         assert!(offset + length <= self.len, "Requested slice is out of bounds");
+//         let adjusted_data = unsafe { self.data.add(offset) };
+//         // Fail(Allocated): 'adjusted_data' points to uninit memory
+//         // Fail(Aligned): 'adjusted_data' may be not aligned due to the offset
+//         unsafe { slice::from_raw_parts(adjusted_data, length) }
+//     }
+// }
+
+
+// fn test1() {
+//     let len: usize = 0;
+//     let data = ptr::null::<i32>();
+//     // Fail(Allocated): 'data' is null, which violates the requirement that it must be non-null
+//     let slice: &[i32] = unsafe { slice::from_raw_parts(data, len) };
+// }
+
+// fn test2() {
+//     let len: usize = 3;
+//     let uninit_data = MaybeUninit::<[i32; 3]>::uninit();
+//     let data = uninit_data.as_ptr() as *const i32;
+//     // Fail(Initialized): 'data' points to uninitialized memory, which violates the initialization requirement
+//     let slice: &[i32] = unsafe { slice::from_raw_parts(data, len) };
+//     println!("First element: {}", slice[0]);
+// }
+
+// fn test3() {
+//     let part1 = Box::new(1);
+//     let part2 = Box::new(2);
+//     let data = [Box::into_raw(part1), Box::into_raw(part2)].as_ptr() as *const i32;
+//     let len = 2;
+//     // Fail(Dereferencable): 'data' points across multiple allocated objects, violating the single allocation constraint
+//     let slice: &[i32] = unsafe { slice::from_raw_parts(data, len) };
+//     println!("Slice elements: {:?}", slice);
+// }
+
+// fn test4() {
+//     let unaligned = [0u8; 5];
+//     let data = unaligned.as_ptr().wrapping_offset(1) as *const i32;
+//     let len = 1;
+//     // Fail(Layout): 'data' is not aligned, violating the alignment requirement
+//     let slice: &[i32] = unsafe { slice::from_raw_parts(data, len) };
+//     println!("Slice elements: {:?}", slice);
+// }
+
+// fn test5(offset:usize) {
+//     let unaligned = [0u32; 5];
+//     let ptr = unaligned.as_ptr() as *const u8;
+//     let data = unsafe { ptr.add(offset) as *const i32 };
+//     let len = 1;
+//     // Fail(Layout): 'data' is not aligned, violating the alignment requirement
+//     let slice: &[i32] = unsafe { slice::from_raw_parts(data, len) };
+//     println!("Slice elements: {:?}", slice);
+// }
+
+
+/// offset: _1 
+/// unaligned: _2
+/// unaligned.as_ptr(): _4
+/// ptr: _3
+/// data: _7 _12
+ unsafe fn test5(_offset:usize) {
+    let unaligned = [0u32; 5];
+    let ptr = unaligned.as_ptr() as *const u8;
+    let data = ptr as *mut i32;
+    let len = 1;
+    // Fail(Layout): 'data' is not aligned, violating the alignment requirement
+    let _slice: &[i32] = slice::from_raw_parts_mut(data, len);
+    // println!("Slice elements: {:?}", slice);
+}
+
+// fn test5() {
+//     let data: *const u8 = Box::leak(Box::new(0));
+//     let len: usize = (isize::MAX as usize) / std::mem::size_of::<u8>() + 1;
+//     // Pass(Allocated \ Aligned):   data is allocated and aligned
+//     // Fail(Bounded): 'len' is out of the max value
+//     // Fail(Dereferencable \ Initialized): 'data' onnly points to the memory with a 'u8' size, but the 'len' is out of this range
+//     let slice: &[u8] = unsafe { slice::from_raw_parts(data, len) };
+//     if let Some(last_element) = slice.last() {
+//         println!("Last element: {}", last_element);
+//     } else {
+//         println!("Slice is empty");
+//     }
+// }
+
+
+pub trait MySpecialTrait2 {
+    fn is_special(&self) -> bool;
+}
+impl MySpecialTrait2 for i8 {
+    fn is_special(&self) -> bool { *self > 0 }
+}
+impl MySpecialTrait2 for f64 {
+    fn is_special(&self) -> bool { self.is_sign_positive() }
+}
+
+pub trait MySpecialTrait {
+    fn is_special(&self) -> bool;
+}
+impl MySpecialTrait for i8 {
+    fn is_special(&self) -> bool { *self > 0 }
+}
+impl MySpecialTrait for f32 {
+    fn is_special(&self) -> bool { self.is_sign_positive() }
+}
+
+
+pub fn test6<T: MySpecialTrait2 + Copy, U: MySpecialTrait + Copy>(a: &mut [T], _b: &[U; 20]) {
+    unsafe {
+        let _c = std::slice::from_raw_parts_mut(a.as_mut_ptr() as *mut U, 20);
+        // for i in 0..20 {
+        //     c[i] ^= b[i];
+        // }
+    }
+}
+
+pub fn test7(a: &mut [u8], b: &[u32; 20]) {
+    unsafe {
+        let c = slice::from_raw_parts_mut(a.as_mut_ptr() as *mut u32, 20);
+        for i in 0..20 {
+            c[i] ^= b[i];
+        }
+    }
+}
+
+fn main() {
+    unsafe {test5(3)};
+    let mut x = [0u8;40];
+    let y = [0u32;20];
+    test7(&mut x[1..32], &y);
+}


### PR DESCRIPTION
Now the `senryx` is updated to support alignment analysis of generic type.

Specifically, in the function with generic params, `senryx` will extract all the possible types that satisfy the trait bounds. Then when the unsafe function requiring `arg` to be aligned is called, alignment check will be performed to verify whether all the satisfied typed can pass the align contract.

Test case:
```
cd tests/support/safety_check/slice_from_raw_parts
cargo rapx -A
```
The test case shows two scenarios that one contains generic params while another doesn't.