### PR TITLE
[api-dep] fix: lint warnings

### DIFF
--- a/rapx/src/analysis/api_dep/mod.rs
+++ b/rapx/src/analysis/api_dep/mod.rs
@@ -1,7 +1,16 @@
+/// NOTE: This analysis module is currently under development and is highly unstable.
+/// The #[allow(unused)] attribute is applied to suppress excessive lint warnings.
+/// Once the analysis stabilizes, this marker should be removed.
+
+#[allow(unused)]
 mod extract;
+#[allow(unused)]
 mod graph;
+#[allow(unused)]
 mod lifetime;
+#[allow(unused)]
 mod visitor;
+
 use crate::{rap_debug, rap_info};
 use graph::ApiDepGraph;
 use rustc_hir::def_id::LOCAL_CRATE;

--- a/rapx/src/analysis/api_dep/visitor.rs
+++ b/rapx/src/analysis/api_dep/visitor.rs
@@ -36,9 +36,9 @@ impl<'tcx, 'a> FnVisitor<'tcx, 'a> {
     pub fn fn_cnt(&self) -> usize {
         self.fn_cnt
     }
-    pub fn write_funcs<T: Write>(&self, F: &mut T) {
+    pub fn write_funcs<T: Write>(&self, f: &mut T) {
         for id in &self.funcs {
-            write!(F, "{}\n", self.tcx.def_path_str(id)).expect("fail when write funcs");
+            write!(f, "{}\n", self.tcx.def_path_str(id)).expect("fail when write funcs");
         }
     }
 }


### PR DESCRIPTION
Addressed excessive lint warnings by applying the `#[allow(unused)]` attribute to modules under development.