### PR TITLE
Feat: add next iterator checks

### DIFF
--- a/rapx/src/analysis/opt.rs
+++ b/rapx/src/analysis/opt.rs
@@ -1,5 +1,6 @@
 pub mod checking;
 pub mod data_collection;
+pub mod iterator;
 pub mod memory_cloning;
 
 use rustc_middle::ty::TyCtxt;
@@ -9,6 +10,7 @@ use crate::rap_warn;
 use super::core::dataflow::{graph::Graph, DataFlow};
 use checking::bounds_checking::BoundsCheck;
 use data_collection::slice_contains::SliceContainsCheck;
+use iterator::next_iterator::NextIteratorCheck;
 use memory_cloning::used_as_immutable::UsedAsImmutableCheck;
 
 pub struct Opt<'tcx> {
@@ -56,9 +58,19 @@ impl<'tcx> Opt<'tcx> {
                 slice_contains_check
             })
             .collect();
+        let next_iterator_checks: Vec<NextIteratorCheck> = dataflow
+            .graphs
+            .iter()
+            .map(|(_, graph)| {
+                let mut next_iterator_check = NextIteratorCheck::new();
+                next_iterator_check.check(graph, &self.tcx);
+                next_iterator_check
+            })
+            .collect();
         if !(bounds_checks.is_empty()
             && used_as_immutable_checks.is_empty()
-            && slice_contains_checks.is_empty())
+            && slice_contains_checks.is_empty()
+            && next_iterator_checks.is_empty())
         {
             rap_warn!("Performance Issues detected");
             for ((_, graph), bounds_check) in dataflow.graphs.iter().zip(bounds_checks.iter()) {
@@ -73,6 +85,11 @@ impl<'tcx> Opt<'tcx> {
                 dataflow.graphs.iter().zip(slice_contains_checks.iter())
             {
                 slice_contains_check.report(graph);
+            }
+            for ((_, graph), next_iterator_check) in
+                dataflow.graphs.iter().zip(next_iterator_checks.iter())
+            {
+                next_iterator_check.report(graph);
             }
         }
     }

--- a/rapx/src/analysis/opt.rs
+++ b/rapx/src/analysis/opt.rs
@@ -61,10 +61,14 @@ impl<'tcx> Opt<'tcx> {
         let next_iterator_checks: Vec<NextIteratorCheck> = dataflow
             .graphs
             .iter()
-            .map(|(_, graph)| {
+            .filter_map(|(_, graph)| {
                 let mut next_iterator_check = NextIteratorCheck::new();
                 next_iterator_check.check(graph, &self.tcx);
-                next_iterator_check
+                if next_iterator_check.valid {
+                    Some(next_iterator_check)
+                } else {
+                    None
+                }
             })
             .collect();
         if !(bounds_checks.is_empty()

--- a/rapx/src/analysis/opt/checking/bounds_checking/bounds_loop_push.rs
+++ b/rapx/src/analysis/opt/checking/bounds_checking/bounds_loop_push.rs
@@ -61,7 +61,10 @@ impl<'tcx> intravisit::Visitor<'tcx> for LoopFinder<'tcx> {
                 record: Vec::new(),
             };
             intravisit::walk_block(&mut push_finder, block);
-            if !push_finder.record.is_empty() {
+            // if !push_finder.record.is_empty() {
+            //     self.record.push((ex.span, push_finder.record));
+            // }
+            if push_finder.record.len() == 1 { // we only use simple cases
                 self.record.push((ex.span, push_finder.record));
             }
         }

--- a/rapx/src/analysis/opt/checking/bounds_checking/bounds_loop_push.rs
+++ b/rapx/src/analysis/opt/checking/bounds_checking/bounds_loop_push.rs
@@ -64,7 +64,8 @@ impl<'tcx> intravisit::Visitor<'tcx> for LoopFinder<'tcx> {
             // if !push_finder.record.is_empty() {
             //     self.record.push((ex.span, push_finder.record));
             // }
-            if push_finder.record.len() == 1 { // we only use simple cases
+            if push_finder.record.len() == 1 {
+                // we only use simple cases
                 self.record.push((ex.span, push_finder.record));
             }
         }

--- a/rapx/src/analysis/opt/data_collection/slice_contains.rs
+++ b/rapx/src/analysis/opt/data_collection/slice_contains.rs
@@ -89,12 +89,12 @@ fn report_slice_contains_bug(graph: &Graph, contains_span: Span) {
         .annotation(
             Level::Error
                 .span(relative_pos_range(graph.span, contains_span))
-                .label("Vec contains happens here."),
+                .label("Slice contains happens here."),
         );
     let message = Level::Warning
         .title("Improper data collection detected")
         .snippet(snippet)
-        .footer(Level::Help.title("Use Set instead of Vec."));
+        .footer(Level::Help.title("Use Set instead of Slice."));
     let renderer = Renderer::styled();
     println!("{}", renderer.render(message));
 }

--- a/rapx/src/analysis/opt/iterator.rs
+++ b/rapx/src/analysis/opt/iterator.rs
@@ -1,0 +1,1 @@
+pub mod next_iterator;

--- a/rapx/src/analysis/opt/iterator/next_iterator.rs
+++ b/rapx/src/analysis/opt/iterator/next_iterator.rs
@@ -1,0 +1,110 @@
+use once_cell::sync::OnceCell;
+
+use rustc_hir::{intravisit, Expr, ExprKind};
+use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::TypeckResults;
+use rustc_span::Span;
+
+use crate::analysis::core::dataflow::graph::Graph;
+use crate::analysis::opt::OptCheck;
+use crate::analysis::utils::def_path::DefPath;
+use crate::utils::log::{
+    relative_pos_range, span_to_filename, span_to_first_line, span_to_line_number,
+    span_to_source_code, span_to_trimmed_span,
+};
+use annotate_snippets::{Level, Renderer, Snippet};
+
+static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
+
+struct DefPaths {
+    iter_next: DefPath,
+    iter_chain: DefPath,
+}
+
+impl DefPaths {
+    pub fn new(tcx: &TyCtxt<'_>) -> Self {
+        Self {
+            iter_next: DefPath::new("std::iter::Iterator::next", tcx),
+            iter_chain: DefPath::new("std::iter::Iterator::chain", tcx),
+        }
+    }
+}
+
+struct NextFinder<'tcx> {
+    typeck_results: &'tcx TypeckResults<'tcx>,
+    next_record: Vec<Span>,
+    chain_record: Vec<Span>,
+}
+
+impl<'tcx> intravisit::Visitor<'tcx> for NextFinder<'tcx> {
+    fn visit_expr(&mut self, ex: &'tcx Expr<'tcx>) {
+        if let ExprKind::MethodCall(.., span) = ex.kind {
+            let def_id = self
+                .typeck_results
+                .type_dependent_def_id(ex.hir_id)
+                .unwrap();
+            let next_def_id = (&DEFPATHS.get().unwrap()).iter_next.last_def_id();
+            let chain_def_id = (&DEFPATHS.get().unwrap()).iter_chain.last_def_id();
+            if def_id == next_def_id {
+                self.next_record.push(span);
+            }
+            if def_id == chain_def_id {
+                self.chain_record.push(span);
+            }
+        }
+        intravisit::walk_expr(self, ex);
+    }
+}
+
+pub struct NextIteratorCheck {
+    next_record: Vec<Span>,
+    chain_record: Vec<Span>,
+}
+
+impl OptCheck for NextIteratorCheck {
+    fn new() -> Self {
+        Self {
+            next_record: Vec::new(),
+            chain_record: Vec::new(),
+        }
+    }
+
+    fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
+        let _ = &DEFPATHS.get_or_init(|| DefPaths::new(tcx));
+        let def_id = graph.def_id;
+        let body = tcx.hir().body_owned_by(def_id.as_local().unwrap());
+        let typeck_results = tcx.typeck(def_id.as_local().unwrap());
+        let mut next_chain_finder = NextFinder {
+            typeck_results,
+            next_record: Vec::new(),
+            chain_record: Vec::new(),
+        };
+        intravisit::walk_body(&mut next_chain_finder, body);
+        self.next_record = next_chain_finder.next_record;
+        self.chain_record = next_chain_finder.chain_record;
+    }
+
+    fn report(&self, graph: &Graph) {
+        report_next_iterator_bug(&self.next_record, &self.chain_record, graph.span);
+    }
+}
+
+fn report_next_iterator_bug(next_record: &Vec<Span>, chain_record: &Vec<Span>, graph_span: Span) {
+    let code_source = span_to_source_code(graph_span);
+    let filename = span_to_filename(graph_span);
+    let mut snippet = Snippet::source(&code_source)
+        .line_start(span_to_line_number(graph_span))
+        .origin(&filename)
+        .fold(true);
+    for next_span in next_record {
+        snippet = snippet.annotation(Level::Error.span(relative_pos_range(graph_span, *next_span)))
+    }
+    for chain_span in chain_record {
+        snippet = snippet.annotation(Level::Error.span(relative_pos_range(graph_span, *chain_span)))
+    }
+    let message = Level::Warning
+        .title("Inefficient iterators detected")
+        .snippet(snippet);
+    let renderer = Renderer::styled();
+    println!("{}", renderer.render(message));
+}

--- a/tests/support/opt/iter_chunk/Cargo.toml
+++ b/tests/support/opt/iter_chunk/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "iter_chunk"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/tests/support/opt/iter_chunk/src/lib.rs
+++ b/tests/support/opt/iter_chunk/src/lib.rs
@@ -1,0 +1,13 @@
+pub fn foo(v: &mut Vec<i32>) {
+    let mut iter = v.iter();
+    
+    use std::iter::once;
+
+    let r = iter.next();
+    let g = iter.next();
+    let b = iter.next();
+    let a = iter.next();
+
+    Some(once(b).chain(once(g)).chain(once(r)).chain(once(a)));
+}
+

--- a/tests/support/opt/slice_contains/Cargo.toml
+++ b/tests/support/opt/slice_contains/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vec_contains"
+name = "slice_contains"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/support/opt/slice_contains/src/lib.rs
+++ b/tests/support/opt/slice_contains/src/lib.rs
@@ -1,0 +1,5 @@
+fn foo(a: Vec<i32>, b: Vec<i32>) {
+    for i in b.iter() {
+        if a.contains(i) {}
+    }
+}

--- a/tests/support/opt/vec_contains/src/lib.rs
+++ b/tests/support/opt/vec_contains/src/lib.rs
@@ -1,5 +1,0 @@
-fn foo(a: Vec<i32>, b: Vec<i32>) {
-    for i in b.iter() {
-        if a.contains(i) {}
-    }
-}


### PR DESCRIPTION
- Detect whether a function uses both `next` and `chain` method of `iterator` which might be optimized by using `chunk` iterators.
- Reduce false positives by filtering in bounds checks