### PR TITLE
support hashmap in hash key cloning

### DIFF
--- a/rapx/src/analysis/opt/memory_cloning/hash_key_cloning.rs
+++ b/rapx/src/analysis/opt/memory_cloning/hash_key_cloning.rs
@@ -23,7 +23,11 @@ use crate::utils::log::{
 
 struct DefPaths {
     hashset_insert: DefPath,
+    hashmap_insert: DefPath,
     hashset_new: DefPath,
+    hashmap_new: DefPath,
+    hashset_with: DefPath,
+    hashmap_with: DefPath,
     clone: DefPath,
 }
 
@@ -31,36 +35,32 @@ impl DefPaths {
     pub fn new(tcx: &TyCtxt<'_>) -> Self {
         Self {
             hashset_insert: DefPath::new("std::collections::HashSet::insert", tcx),
+            hashmap_insert: DefPath::new("std::collections::HashMap::insert", tcx),
             hashset_new: DefPath::new("std::collections::HashSet::new", tcx),
+            hashset_with: DefPath::new("std::collections::HashSet::with_capacity", tcx),
+            hashmap_new: DefPath::new("std::collections::HashMap::new", tcx),
+            hashmap_with: DefPath::new("std::collections::HashMap::with_capacity", tcx),
             clone: DefPath::new("std::clone::Clone::clone", tcx),
         }
     }
 }
 
-struct HashSetInsertFinder<'tcx> {
+struct HashInsertFinder<'tcx> {
     typeck_results: &'tcx TypeckResults<'tcx>,
     record: HashSet<Span>,
 }
 
-impl<'tcx> intravisit::Visitor<'tcx> for HashSetInsertFinder<'tcx> {
+impl<'tcx> intravisit::Visitor<'tcx> for HashInsertFinder<'tcx> {
     fn visit_expr(&mut self, ex: &'tcx Expr<'tcx>) {
-        if let ExprKind::MethodCall(_, receiver, ..) = ex.kind {
+        if let ExprKind::MethodCall(..) = ex.kind {
             let def_id = self
                 .typeck_results
                 .type_dependent_def_id(ex.hir_id)
                 .unwrap();
-            let target_def_id = (&DEFPATHS.get().unwrap()).hashset_insert.last_def_id();
-            if def_id == target_def_id {
-                let ty = self.typeck_results.node_type(receiver.hir_id);
-                if let TyKind::Adt(.., generic_args) = ty.kind() {
-                    // we check whether the first generic arg is a ref type
-                    if !matches!(
-                        generic_args.get(0).unwrap().expect_ty().kind(),
-                        TyKind::Ref(..)
-                    ) {
-                        self.record.insert(ex.span);
-                    }
-                }
+            if def_id == DEFPATHS.get().unwrap().hashset_insert.last_def_id()
+                || def_id == DEFPATHS.get().unwrap().hashmap_insert.last_def_id()
+            {
+                self.record.insert(ex.span);
             }
         }
         intravisit::walk_expr(self, ex);
@@ -94,16 +94,19 @@ fn find_first_param_upside_clone(graph: &Graph, node: &GraphNode) -> Option<Loca
     clone_node_idx
 }
 
-// find the upside "new" node of the "insert" node if it exists
-fn find_hashset_new_node(graph: &Graph, node: &GraphNode) -> Option<Local> {
+// find the upside "new" node or "with_capacity" node of the "insert" node if it exists
+fn find_hash_new_node(graph: &Graph, node: &GraphNode) -> Option<Local> {
     let mut new_node_idx = None;
     let def_paths = &DEFPATHS.get().unwrap();
-    let target_def_id = def_paths.hashset_new.last_def_id();
     let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
         let node = &graph.nodes[idx];
         for op in node.ops.iter() {
             if let NodeOp::Call(def_id) = op {
-                if *def_id == target_def_id {
+                if *def_id == def_paths.hashset_new.last_def_id()
+                    || *def_id == def_paths.hashmap_new.last_def_id()
+                    || *def_id == def_paths.hashset_with.last_def_id()
+                    || *def_id == def_paths.hashmap_with.last_def_id()
+                {
                     new_node_idx = Some(idx);
                     return DFSStatus::Stop;
                 }
@@ -160,15 +163,15 @@ impl OptCheck for HashKeyCloningCheck {
         let def_id = graph.def_id;
         let body = tcx.hir().body_owned_by(def_id.as_local().unwrap());
         let typeck_results = tcx.typeck(def_id.as_local().unwrap());
-        let mut hashset_finder = HashSetInsertFinder {
+        let mut hash_finder = HashInsertFinder {
             typeck_results,
             record: HashSet::new(),
         };
-        intravisit::walk_body(&mut hashset_finder, body);
+        intravisit::walk_body(&mut hash_finder, body);
         for node in graph.nodes.iter() {
-            if hashset_finder.record.contains(&node.span) {
+            if hash_finder.record.contains(&node.span) {
                 if let Some(clone_node_idx) = find_first_param_upside_clone(graph, node) {
-                    if let Some(new_node_idx) = find_hashset_new_node(graph, node) {
+                    if let Some(new_node_idx) = find_hash_new_node(graph, node) {
                         if !graph.is_connected(new_node_idx, Local::from_usize(0)) {
                             let clone_span = graph.nodes[clone_node_idx].span;
                             self.record.push((clone_span, node.span));


### PR DESCRIPTION
Add hashmap related function and add `with_capacity` detection (the original version only detects `new`)