### PR TITLE
support bounds checking of no_std

### DIFF
--- a/rapx/src/analysis/core/dataflow.rs
+++ b/rapx/src/analysis/core/dataflow.rs
@@ -37,7 +37,8 @@ impl<'tcx> DataFlow<'tcx> {
 
     pub fn build_graphs(&mut self) {
         for local_def_id in self.tcx.iter_local_def_id() {
-            if matches!(self.tcx.def_kind(local_def_id), DefKind::Fn) {
+            let def_kind = self.tcx.def_kind(local_def_id);
+            if matches!(def_kind, DefKind::Fn) || matches!(def_kind, DefKind::AssocFn) {
                 let hir_map = self.tcx.hir();
                 if hir_map.maybe_body_owned_by(local_def_id).is_some() {
                     let def_id = local_def_id.to_def_id();

--- a/rapx/src/analysis/core/dataflow/graph.rs
+++ b/rapx/src/analysis/core/dataflow/graph.rs
@@ -274,7 +274,7 @@ impl Graph {
                     self.nodes[dst].ops[seq] = NodeOp::NullaryOp;
                 }
                 Rvalue::ThreadLocalRef(_) => {
-                    todo!()
+                    //todo!()
                 }
                 Rvalue::Discriminant(place) => {
                     let src = self.parse_place(place);

--- a/rapx/src/analysis/opt.rs
+++ b/rapx/src/analysis/opt.rs
@@ -12,6 +12,14 @@ use data_collection::unreserved_hash::UnreservedHashCheck;
 use iterator::next_iterator::NextIteratorCheck;
 use memory_cloning::hash_key_cloning::HashKeyCloningCheck;
 
+use lazy_static::lazy_static;
+use rustc_span::symbol::Symbol;
+use std::sync::Mutex;
+
+lazy_static! {
+    pub static ref NO_STD: Mutex<bool> = Mutex::new(false);
+}
+
 pub struct Opt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
 }
@@ -27,31 +35,52 @@ impl<'tcx> Opt<'tcx> {
         Self { tcx }
     }
 
+    fn has_crate(&self, name: &str) -> bool {
+        for num in self.tcx.crates(()) {
+            if self.tcx.crate_name(*num) == Symbol::intern(name) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn start(&mut self) {
         let mut dataflow = DataFlow::new(self.tcx, false);
         dataflow.build_graphs();
+        {
+            let mut no_std = NO_STD.lock().unwrap();
+            *no_std = !self.has_crate("std");
+        }
+        if !self.has_crate("core") {
+            //core it self
+            return;
+        }
+
         dataflow.graphs.iter().for_each(|(_, graph)| {
             let mut bounds_check = BoundsCheck::new();
             bounds_check.check(graph, &self.tcx);
             bounds_check.report(graph);
 
-            let mut hash_key_cloning_check = HashKeyCloningCheck::new();
-            hash_key_cloning_check.check(graph, &self.tcx);
-            hash_key_cloning_check.report(graph);
+            let no_std = NO_STD.lock().unwrap();
+            if !*no_std {
+                let mut hash_key_cloning_check = HashKeyCloningCheck::new();
+                hash_key_cloning_check.check(graph, &self.tcx);
+                hash_key_cloning_check.report(graph);
 
-            let mut slice_contains_check = SliceContainsCheck::new();
-            slice_contains_check.check(graph, &self.tcx);
-            slice_contains_check.report(graph);
+                let mut slice_contains_check = SliceContainsCheck::new();
+                slice_contains_check.check(graph, &self.tcx);
+                slice_contains_check.report(graph);
 
-            let mut next_iterator_check = NextIteratorCheck::new();
-            next_iterator_check.check(graph, &self.tcx);
-            if next_iterator_check.valid {
-                next_iterator_check.report(graph);
+                let mut next_iterator_check = NextIteratorCheck::new();
+                next_iterator_check.check(graph, &self.tcx);
+                if next_iterator_check.valid {
+                    next_iterator_check.report(graph);
+                }
+
+                let mut unreserved_hash_check = UnreservedHashCheck::new();
+                unreserved_hash_check.check(graph, &self.tcx);
+                unreserved_hash_check.report(graph);
             }
-
-            let mut unreserved_hash_check = UnreservedHashCheck::new();
-            unreserved_hash_check.check(graph, &self.tcx);
-            unreserved_hash_check.report(graph);
         });
     }
 }

--- a/rapx/src/analysis/opt/checking/bounds_checking/bounds_len.rs
+++ b/rapx/src/analysis/opt/checking/bounds_checking/bounds_len.rs
@@ -12,6 +12,8 @@ use crate::utils::log::{
 };
 use annotate_snippets::{Level, Renderer, Snippet};
 
+use super::super::super::NO_STD;
+
 static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
 
 struct DefPaths {
@@ -23,11 +25,21 @@ struct DefPaths {
 
 impl DefPaths {
     pub fn new(tcx: &TyCtxt<'_>) -> Self {
-        Self {
-            ops_range: DefPath::new("std::ops::Range", tcx),
-            vec_len: DefPath::new("std::vec::Vec::len", tcx),
-            ops_index: DefPath::new("std::ops::Index::index", tcx),
-            ops_index_mut: DefPath::new("std::ops::IndexMut::index_mut", tcx),
+        let no_std = NO_STD.lock().unwrap();
+        if *no_std {
+            Self {
+                ops_range: DefPath::new("core::ops::Range", tcx),
+                vec_len: DefPath::new("alloc::vec::Vec::len", tcx),
+                ops_index: DefPath::new("core::ops::Index::index", tcx),
+                ops_index_mut: DefPath::new("core::ops::IndexMut::index_mut", tcx),
+            }
+        } else {
+            Self {
+                ops_range: DefPath::new("std::ops::Range", tcx),
+                vec_len: DefPath::new("std::vec::Vec::len", tcx),
+                ops_index: DefPath::new("std::ops::Index::index", tcx),
+                ops_index_mut: DefPath::new("std::ops::IndexMut::index_mut", tcx),
+            }
         }
     }
 }

--- a/rapx/src/analysis/opt/checking/bounds_checking/bounds_loop_push.rs
+++ b/rapx/src/analysis/opt/checking/bounds_checking/bounds_loop_push.rs
@@ -13,6 +13,7 @@ use crate::utils::log::{
 };
 use annotate_snippets::{Level, Renderer, Snippet};
 
+use super::super::super::NO_STD;
 static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
 
 struct DefPaths {
@@ -21,8 +22,15 @@ struct DefPaths {
 
 impl DefPaths {
     pub fn new(tcx: &TyCtxt<'_>) -> Self {
-        Self {
-            vec_push: DefPath::new("std::vec::Vec::push", tcx),
+        let no_std = NO_STD.lock().unwrap();
+        if *no_std {
+            Self {
+                vec_push: DefPath::new("alloc::vec::Vec::push", tcx),
+            }
+        } else {
+            Self {
+                vec_push: DefPath::new("std::vec::Vec::push", tcx),
+            }
         }
     }
 }


### PR DESCRIPTION
Now RAPx -opt can support the standard library using the command of `cargo rapx -opt -- -Z build-std --target x86_64-unknown-linux-gnu`.

The compiling of std starts from `core` then `alloc` and ends with `std`. This PR pre-checks whether the tcx has a context of `std` first and then controls the following checking entries. `vec` in `std` is actually loaded from `alloc::vec`. Thus it makes sense to find bound checks in std library.