### PR TITLE
Add encoding checks and fix bugs

### DIFF
--- a/rapx/src/analysis/core/dataflow/debug.rs
+++ b/rapx/src/analysis/core/dataflow/debug.rs
@@ -45,10 +45,18 @@ impl GraphNode {
                 NodeOp::Nop => {
                     write!(attr, "label=\"{:?} ", local).unwrap();
                 }
-                NodeOp::Const(ref name) => {
-                    write!(attr, "label=\"<f0> {:?} {} ", local, escaped_string(name.clone())).unwrap();
+                NodeOp::Const(ref src_desc, ref src_ty) => {
+                    write!(
+                        attr,
+                        "label=\"<f0> {:?} {} {} ",
+                        local,
+                        escaped_string(src_desc.clone()),
+                        escaped_string(src_ty.clone()),
+                    )
+                    .unwrap();
                 }
-                NodeOp::Use => { // only exists for _a[_b] =(Use) value
+                NodeOp::Use => {
+                    // only exists for _a[_b] =(Use) value
                     write!(attr, "label=\"{:?} ", local).unwrap();
                 }
                 _ => {

--- a/rapx/src/analysis/core/dataflow/debug.rs
+++ b/rapx/src/analysis/core/dataflow/debug.rs
@@ -43,13 +43,16 @@ impl GraphNode {
             assert!(self.ops.len() == 1);
             match self.ops[0] {
                 NodeOp::Nop => {
-                    write!(attr, "label=\" ").unwrap();
+                    write!(attr, "label=\"{:?} ", local).unwrap();
                 }
                 NodeOp::Const(ref name) => {
-                    write!(attr, "label=\"<f0> {} ", escaped_string(name.clone())).unwrap();
+                    write!(attr, "label=\"<f0> {:?} {} ", local, escaped_string(name.clone())).unwrap();
+                }
+                NodeOp::Use => { // only exists for _a[_b] =(Use) value
+                    write!(attr, "label=\"{:?} ", local).unwrap();
                 }
                 _ => {
-                    panic!("Wrong arm!");
+                    panic!("Wrong arm!  {:?} {:?}", local, self.ops[0]);
                 }
             }
         } else {

--- a/rapx/src/analysis/core/dataflow/graph.rs
+++ b/rapx/src/analysis/core/dataflow/graph.rs
@@ -164,7 +164,7 @@ impl Graph {
                 }
                 PlaceElem::Index(idx) => {
                     graph.add_node_edge(src, dst, EdgeOp::Index);
-                    graph.add_node_edge(idx, dst, EdgeOp::Index); //Warning: no difference between src and idx in graph
+                    graph.add_node_edge(idx, dst, EdgeOp::Nop);
                 }
                 PlaceElem::ConstantIndex { .. } => {
                     graph.add_node_edge(src, dst, EdgeOp::ConstIndex);

--- a/rapx/src/analysis/core/dataflow/graph.rs
+++ b/rapx/src/analysis/core/dataflow/graph.rs
@@ -15,7 +15,7 @@ pub enum NodeOp {
     //warning: the fields are related to the version of the backend rustc version
     Nop,
     Err,
-    Const(String),
+    Const(String, String),
     //Rvalue
     Use,
     Repeat,
@@ -123,10 +123,16 @@ impl Graph {
     }
 
     // add an edge into an existing node with const value as src
-    pub fn add_const_edge(&mut self, src: String, dst: Local, op: EdgeOp) -> EdgeIdx {
+    pub fn add_const_edge(
+        &mut self,
+        src_desc: String,
+        src_ty: String,
+        dst: Local,
+        op: EdgeOp,
+    ) -> EdgeIdx {
         let seq = self.nodes[dst].seq;
         let mut const_node = GraphNode::new();
-        const_node.ops[0] = NodeOp::Const(src);
+        const_node.ops[0] = NodeOp::Const(src_desc, src_ty);
         let src = self.nodes.push(const_node);
         let edge_idx = self.edges.push(GraphEdge { src, dst, op, seq });
         self.nodes[dst].in_edges.push(edge_idx);
@@ -144,7 +150,13 @@ impl Graph {
                 self.add_node_edge(src, dst, EdgeOp::Move);
             }
             Operand::Constant(boxed_const_op) => {
-                self.add_const_edge(boxed_const_op.const_.to_string(), dst, EdgeOp::Const);
+                let src_desc = boxed_const_op.const_.to_string();
+                let src_ty = match boxed_const_op.const_ {
+                    Const::Val(_, ty) => ty.to_string(),
+                    Const::Unevaluated(_, ty) => ty.to_string(),
+                    Const::Ty(ty, _) => ty.to_string(),
+                };
+                self.add_const_edge(src_desc, src_ty, dst, EdgeOp::Const);
             }
         }
     }
@@ -270,7 +282,7 @@ impl Graph {
                     self.nodes[dst].ops[seq] = NodeOp::UnaryOp;
                 }
                 Rvalue::NullaryOp(_, ty) => {
-                    self.add_const_edge(ty.to_string(), dst, EdgeOp::Nop);
+                    self.add_const_edge(ty.to_string(), ty.to_string(), dst, EdgeOp::Nop);
                     self.nodes[dst].ops[seq] = NodeOp::NullaryOp;
                 }
                 Rvalue::ThreadLocalRef(_) => {
@@ -410,6 +422,27 @@ impl Graph {
         set
     }
 
+    pub fn collect_ancestor_locals(&self, local: Local, self_included: bool) -> HashSet<Local> {
+        let mut ret = HashSet::new();
+        let mut node_operator = |_: &Graph, idx: Local| -> DFSStatus {
+            ret.insert(idx);
+            DFSStatus::Continue
+        };
+        let mut seen = HashSet::new();
+        self.dfs(
+            local,
+            Direction::Upside,
+            &mut node_operator,
+            &mut Graph::always_true_edge_validator,
+            true,
+            &mut seen,
+        );
+        if !self_included {
+            ret.remove(&local);
+        }
+        ret
+    }
+
     pub fn is_connected(&self, idx_1: Local, idx_2: Local) -> bool {
         let target = idx_2;
         let find = Cell::new(false);
@@ -439,7 +472,7 @@ impl Graph {
                 &mut node_operator,
                 &mut Self::always_true_edge_validator,
                 false,
-                &mut seen
+                &mut seen,
             );
         }
         find.get()
@@ -469,7 +502,7 @@ impl Graph {
         node_operator: &mut F,
         edge_validator: &mut G,
         traverse_all: bool,
-        seen: &mut HashSet<Local>
+        seen: &mut HashSet<Local>,
     ) -> DFSStatus
     where
         F: FnMut(&Graph, Local) -> DFSStatus,

--- a/rapx/src/analysis/opt.rs
+++ b/rapx/src/analysis/opt.rs
@@ -7,6 +7,7 @@ use rustc_middle::ty::TyCtxt;
 
 use super::core::dataflow::{graph::Graph, DataFlow};
 use checking::bounds_checking::BoundsCheck;
+use checking::encoding_checking::EncodingCheck;
 use data_collection::slice_contains::SliceContainsCheck;
 use data_collection::unreserved_hash::UnreservedHashCheck;
 use iterator::next_iterator::NextIteratorCheck;
@@ -63,6 +64,10 @@ impl<'tcx> Opt<'tcx> {
 
             let no_std = NO_STD.lock().unwrap();
             if !*no_std {
+                let mut encoding_check = EncodingCheck::new();
+                encoding_check.check(graph, &self.tcx);
+                encoding_check.report(graph);
+
                 let mut hash_key_cloning_check = HashKeyCloningCheck::new();
                 hash_key_cloning_check.check(graph, &self.tcx);
                 hash_key_cloning_check.report(graph);

--- a/rapx/src/analysis/opt/checking.rs
+++ b/rapx/src/analysis/opt/checking.rs
@@ -1,1 +1,2 @@
 pub mod bounds_checking;
+pub mod encoding_checking;

--- a/rapx/src/analysis/opt/checking/bounds_checking.rs
+++ b/rapx/src/analysis/opt/checking/bounds_checking.rs
@@ -3,15 +3,18 @@ use rustc_middle::ty::TyCtxt;
 use crate::analysis::core::dataflow::graph::Graph;
 use crate::analysis::opt::OptCheck;
 
+pub mod bounds_extend;
 pub mod bounds_len;
 pub mod bounds_loop_push;
 
+use bounds_extend::BoundsExtendCheck;
 use bounds_len::BoundsLenCheck;
 use bounds_loop_push::BoundsLoopPushCheck;
 
 pub struct BoundsCheck {
     bounds_len: BoundsLenCheck,
     bounds_loop_push: BoundsLoopPushCheck,
+    bounds_extend: BoundsExtendCheck,
 }
 
 impl OptCheck for BoundsCheck {
@@ -19,16 +22,19 @@ impl OptCheck for BoundsCheck {
         Self {
             bounds_len: BoundsLenCheck::new(),
             bounds_loop_push: BoundsLoopPushCheck::new(),
+            bounds_extend: BoundsExtendCheck::new(),
         }
     }
 
     fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
         self.bounds_len.check(graph, tcx);
         self.bounds_loop_push.check(graph, tcx);
+        self.bounds_extend.check(graph, tcx);
     }
 
     fn report(&self, graph: &Graph) {
         self.bounds_len.report(graph);
         self.bounds_loop_push.report(graph);
+        self.bounds_extend.report(graph);
     }
 }

--- a/rapx/src/analysis/opt/checking/bounds_checking/bounds_extend.rs
+++ b/rapx/src/analysis/opt/checking/bounds_checking/bounds_extend.rs
@@ -1,0 +1,92 @@
+use once_cell::sync::OnceCell;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+use crate::analysis::core::dataflow::graph::{Graph, GraphNode, NodeOp};
+use crate::analysis::utils::def_path::DefPath;
+use crate::utils::log::{
+    relative_pos_range, span_to_filename, span_to_line_number, span_to_source_code,
+};
+use annotate_snippets::{Level, Renderer, Snippet};
+
+use super::super::super::NO_STD;
+static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
+
+struct DefPaths {
+    vec_extend_from_slice: DefPath,
+}
+
+impl DefPaths {
+    pub fn new(tcx: &TyCtxt<'_>) -> Self {
+        let no_std = NO_STD.lock().unwrap();
+        if *no_std {
+            Self {
+                vec_extend_from_slice: DefPath::new("alloc::vec::Vec::extend_from_slice", &tcx),
+            }
+        } else {
+            Self {
+                vec_extend_from_slice: DefPath::new("std::vec::Vec::extend_from_slice", &tcx),
+            }
+        }
+    }
+}
+
+use crate::analysis::opt::OptCheck;
+
+pub struct BoundsExtendCheck {
+    record: Vec<Span>,
+}
+
+fn is_extend_from_slice(node: &GraphNode) -> bool {
+    let def_paths = DEFPATHS.get().unwrap();
+    for op in node.ops.iter() {
+        if let NodeOp::Call(def_id) = op {
+            if *def_id == def_paths.vec_extend_from_slice.last_def_id() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+impl OptCheck for BoundsExtendCheck {
+    fn new() -> Self {
+        Self { record: Vec::new() }
+    }
+
+    fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
+        let _ = &DEFPATHS.get_or_init(|| DefPaths::new(tcx));
+        for node in graph.nodes.iter() {
+            if is_extend_from_slice(node) {
+                self.record.push(node.span);
+            }
+        }
+    }
+
+    fn report(&self, graph: &Graph) {
+        for span in self.record.iter() {
+            report_extend_bug(graph, *span);
+        }
+    }
+}
+
+fn report_extend_bug(graph: &Graph, span: Span) {
+    let code_source = span_to_source_code(graph.span);
+    let filename = span_to_filename(graph.span);
+    let snippet = Snippet::source(&code_source)
+        .line_start(span_to_line_number(graph.span))
+        .origin(&filename)
+        .fold(true)
+        .annotation(
+            Level::Error
+                .span(relative_pos_range(graph.span, span))
+                .label("Checked here."),
+        );
+    let message = Level::Warning
+        .title("Unnecessary bound checkings detected")
+        .snippet(snippet)
+        .footer(Level::Help.title("Manipulate memory directly."));
+    let renderer = Renderer::styled();
+    println!("{}", renderer.render(message));
+}

--- a/rapx/src/analysis/opt/checking/bounds_checking/bounds_len.rs
+++ b/rapx/src/analysis/opt/checking/bounds_checking/bounds_len.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use once_cell::sync::OnceCell;
 
 use rustc_middle::mir::Local;
@@ -117,12 +119,14 @@ fn find_upside_vec_len_node(graph: &Graph, node_idx: Local) -> Option<Local> {
         }
         DFSStatus::Continue
     };
+    let mut seen = HashSet::new();
     graph.dfs(
         node_idx,
         Direction::Upside,
         &mut node_operator,
         &mut Graph::equivalent_edge_validator,
         false,
+        &mut seen,
     );
     vec_len_node_idx
 }
@@ -145,12 +149,14 @@ fn find_downside_index_node(graph: &Graph, node_idx: Local) -> Vec<Local> {
         }
         DFSStatus::Continue
     };
+    let mut seen = HashSet::new();
     graph.dfs(
         node_idx,
         Direction::Downside,
         &mut node_operator,
         &mut Graph::always_true_edge_validator,
         true,
+        &mut seen,
     );
     index_node_idxs
 }

--- a/rapx/src/analysis/opt/checking/encoding_checking.rs
+++ b/rapx/src/analysis/opt/checking/encoding_checking.rs
@@ -1,137 +1,79 @@
+pub mod array_encoding;
+pub mod vec_encoding;
+
 use std::collections::HashSet;
 
-use once_cell::sync::OnceCell;
-
-use rustc_middle::mir::Local;
-use rustc_middle::ty::TyCtxt;
-use rustc_span::Span;
-
 use crate::analysis::core::dataflow::graph::{
-    DFSStatus, Direction, EdgeIdx, EdgeOp, Graph, GraphNode, NodeOp,
+    DFSStatus, Direction, EdgeIdx, EdgeOp, Graph, NodeOp,
 };
-use crate::analysis::utils::def_path::DefPath;
+use crate::analysis::opt::OptCheck;
 use crate::utils::log::{
     relative_pos_range, span_to_filename, span_to_line_number, span_to_source_code,
 };
 use annotate_snippets::{Level, Renderer, Snippet};
 
-static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
+use array_encoding::ArrayEncodingCheck;
+use rustc_middle::mir::Local;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
 
-struct DefPaths {
-    str_from_utf8: DefPath,
-    string_from_utf8: DefPath,
-    string_from_utf8_lossy: DefPath,
-    vec_new: DefPath,
-    vec_push: DefPath,
-}
-
-impl DefPaths {
-    // only supports push operation (can't support direct assignment)
-    pub fn new(tcx: &TyCtxt<'_>) -> Self {
-        Self {
-            str_from_utf8: DefPath::new("std::str::from_utf8", tcx),
-            string_from_utf8: DefPath::new("std::string::String::from_utf8", tcx),
-            string_from_utf8_lossy: DefPath::new("std::string::String::from_utf8_lossy", tcx),
-            vec_new: DefPath::new("std::vec::Vec::new", tcx),
-            vec_push: DefPath::new("std::vec::Vec::push", tcx),
-        }
-    }
-}
-
-use crate::analysis::opt::OptCheck;
+use vec_encoding::VecEncodingCheck;
 
 pub struct EncodingCheck {
-    record: Vec<Span>,
+    vec_encoding: VecEncodingCheck,
+    array_encoding: ArrayEncodingCheck,
 }
 
-fn extract_vec_if_is_string_from(graph: &Graph, node: &GraphNode) -> Option<Local> {
-    let def_paths = &DEFPATHS.get().unwrap();
-    for op in node.ops.iter() {
-        if let NodeOp::Call(def_id) = op {
-            if *def_id == def_paths.string_from_utf8.last_def_id()
-                || *def_id == def_paths.string_from_utf8_lossy.last_def_id()
-                || *def_id == def_paths.str_from_utf8.last_def_id()
-            {
-                let in_edge = &graph.edges[node.in_edges[0]];
-                return Some(in_edge.src);
-            }
+impl OptCheck for EncodingCheck {
+    fn new() -> Self {
+        Self {
+            vec_encoding: VecEncodingCheck::new(),
+            array_encoding: ArrayEncodingCheck::new(),
         }
     }
-    None
+
+    fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
+        self.vec_encoding.check(graph, tcx);
+        self.array_encoding.check(graph, tcx);
+    }
+
+    fn report(&self, graph: &Graph) {
+        self.vec_encoding.report(graph);
+        self.array_encoding.report(graph);
+    }
 }
 
-fn find_upside_vec_new_node(graph: &Graph, node_idx: Local) -> Option<Local> {
-    let mut vec_new_node_idx = None;
-    let def_paths = &DEFPATHS.get().unwrap();
-    let target_def_id = def_paths.vec_new.last_def_id();
-    // Warning: may traverse all upside nodes and the new result will overwrite on the previous result
-    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
-        let node = &graph.nodes[idx];
-        for op in node.ops.iter() {
-            if let NodeOp::Call(def_id) = op {
-                if *def_id == target_def_id {
-                    vec_new_node_idx = Some(idx);
-                    return DFSStatus::Stop;
-                }
-            }
-        }
-        DFSStatus::Continue
-    };
-    let mut seen = HashSet::new();
-    graph.dfs(
-        node_idx,
-        Direction::Upside,
-        &mut node_operator,
-        &mut Graph::always_true_edge_validator,
-        false,
-        &mut seen
-    );
-    vec_new_node_idx
-}
-
-// todo: we can find downside index node too
-
-fn find_downside_push_node(graph: &Graph, node_idx: Local) -> Vec<Local> {
-    let mut push_node_idxs: Vec<Local> = Vec::new();
-    let def_paths = &DEFPATHS.get().unwrap();
-    // Warning: traverse all downside nodes
-    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
-        let node = &graph.nodes[idx];
-        for op in node.ops.iter() {
-            if let NodeOp::Call(def_id) = op {
-                if *def_id == def_paths.vec_push.last_def_id() {
-                    push_node_idxs.push(idx);
-                    break;
-                }
-            }
-        }
-        DFSStatus::Continue
-    };
-    let mut seen = HashSet::new();
-    graph.dfs(
-        node_idx,
-        Direction::Downside,
-        &mut node_operator,
-        &mut Graph::always_true_edge_validator,
-        true,
-        &mut seen,
-    );
-    push_node_idxs
+fn report_encoding_bug(graph: &Graph, span: Span) {
+    let code_source = span_to_source_code(graph.span);
+    let filename = span_to_filename(graph.span);
+    let snippet = Snippet::source(&code_source)
+        .line_start(span_to_line_number(graph.span))
+        .origin(&filename)
+        .fold(true)
+        .annotation(
+            Level::Error
+                .span(relative_pos_range(graph.span, span))
+                .label("Checked here."),
+        );
+    let message = Level::Warning
+        .title("Unnecessary encoding checkings detected")
+        .snippet(snippet)
+        .footer(Level::Help.title("Use unsafe APIs."));
+    let renderer = Renderer::styled();
+    println!("{}", renderer.render(message));
 }
 
 // Warning: WE APPROXIMATELY VIEW CONST U8s AS SAFE INPUT
 // which may cause wrong result.
 
 // todo: ascii chars are extracted from String variables
-fn value_pushed_is_from_const(graph: &Graph, vec_push_idx: Local) -> bool {
+fn value_is_from_const(graph: &Graph, value_idx: Local) -> bool {
     let mut const_found = false;
-    let pushed_value_edge = &graph.edges[graph.nodes[vec_push_idx].in_edges[1]]; // The second parameter
-    let pushed_value_idx = pushed_value_edge.src;
     let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
         let node = &graph.nodes[idx];
         for op in node.ops.iter() {
-            if let NodeOp::Const(desc) = op {
-                if desc.contains("u8") {
+            if let NodeOp::Const(_, src_ty) = op {
+                if src_ty.contains("u8") {
                     const_found = true;
                     return DFSStatus::Stop;
                 }
@@ -156,7 +98,7 @@ fn value_pushed_is_from_const(graph: &Graph, vec_push_idx: Local) -> bool {
     };
     let mut seen = HashSet::new();
     graph.dfs(
-        pushed_value_idx,
+        value_idx,
         Direction::Upside,
         &mut node_operator,
         &mut edge_validator,
@@ -164,54 +106,4 @@ fn value_pushed_is_from_const(graph: &Graph, vec_push_idx: Local) -> bool {
         &mut seen,
     );
     const_found
-}
-
-impl OptCheck for EncodingCheck {
-    fn new() -> Self {
-        Self { record: Vec::new() }
-    }
-
-    fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
-        let _ = &DEFPATHS.get_or_init(|| DefPaths::new(tcx));
-        for node in graph.nodes.iter() {
-            if let Some(vec_node_idx) = extract_vec_if_is_string_from(graph, node) {
-                if let Some(vec_new_idx) = find_upside_vec_new_node(graph, vec_node_idx) {
-                    let vec_push_indice = find_downside_push_node(graph, vec_new_idx);
-                    for vec_push_idx in vec_push_indice {
-                        if !value_pushed_is_from_const(graph, vec_push_idx) {
-                            self.record.clear();
-                            return;
-                        }
-                    }
-                    self.record.push(node.span);
-                }
-            }
-        }
-    }
-
-    fn report(&self, graph: &Graph) {
-        for span in self.record.iter() {
-            report_encoding_bug(graph, *span);
-        }
-    }
-}
-
-fn report_encoding_bug(graph: &Graph, span: Span) {
-    let code_source = span_to_source_code(graph.span);
-    let filename = span_to_filename(graph.span);
-    let snippet = Snippet::source(&code_source)
-        .line_start(span_to_line_number(graph.span))
-        .origin(&filename)
-        .fold(true)
-        .annotation(
-            Level::Error
-                .span(relative_pos_range(graph.span, span))
-                .label("Checked here."),
-        );
-    let message = Level::Warning
-        .title("Unnecessary encoding checkings detected")
-        .snippet(snippet)
-        .footer(Level::Help.title("Use unsafe APIs."));
-    let renderer = Renderer::styled();
-    println!("{}", renderer.render(message));
 }

--- a/rapx/src/analysis/opt/checking/encoding_checking.rs
+++ b/rapx/src/analysis/opt/checking/encoding_checking.rs
@@ -1,0 +1,205 @@
+use once_cell::sync::OnceCell;
+
+use rustc_middle::mir::Local;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+use crate::analysis::core::dataflow::graph::{
+    DFSStatus, Direction, EdgeIdx, EdgeOp, Graph, GraphNode, NodeOp,
+};
+use crate::analysis::utils::def_path::DefPath;
+use crate::utils::log::{
+    relative_pos_range, span_to_filename, span_to_line_number, span_to_source_code,
+};
+use annotate_snippets::{Level, Renderer, Snippet};
+
+static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
+
+struct DefPaths {
+    string_from_utf8: DefPath,
+    string_from_utf8_lossy: DefPath,
+    vec_new: DefPath,
+    vec_push: DefPath,
+}
+
+impl DefPaths {
+    // only supports push operation (can't support direct assignment)
+    pub fn new(tcx: &TyCtxt<'_>) -> Self {
+        Self {
+            string_from_utf8: DefPath::new("std::string::String::from_utf8", tcx),
+            string_from_utf8_lossy: DefPath::new("std::string::String::from_utf8_lossy", tcx),
+            vec_new: DefPath::new("std::vec::Vec::new", tcx),
+            vec_push: DefPath::new("std::vec::Vec::push", tcx),
+        }
+    }
+}
+
+use crate::analysis::opt::OptCheck;
+
+pub struct EncodingCheck {
+    record: Vec<Span>,
+}
+
+fn extract_vec_if_is_string_from(graph: &Graph, node: &GraphNode) -> Option<Local> {
+    let def_paths = &DEFPATHS.get().unwrap();
+    for op in node.ops.iter() {
+        if let NodeOp::Call(def_id) = op {
+            if *def_id == def_paths.string_from_utf8.last_def_id()
+                || *def_id == def_paths.string_from_utf8_lossy.last_def_id()
+            {
+                let in_edge = &graph.edges[node.in_edges[0]];
+                return Some(in_edge.src);
+            }
+        }
+    }
+    None
+}
+
+fn find_upside_vec_new_node(graph: &Graph, node_idx: Local) -> Option<Local> {
+    let mut vec_new_node_idx = None;
+    let def_paths = &DEFPATHS.get().unwrap();
+    let target_def_id = def_paths.vec_new.last_def_id();
+    // Warning: may traverse all upside nodes and the new result will overwrite on the previous result
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
+        let node = &graph.nodes[idx];
+        for op in node.ops.iter() {
+            if let NodeOp::Call(def_id) = op {
+                if *def_id == target_def_id {
+                    vec_new_node_idx = Some(idx);
+                    return DFSStatus::Stop;
+                }
+            }
+        }
+        DFSStatus::Continue
+    };
+    graph.dfs(
+        node_idx,
+        Direction::Upside,
+        &mut node_operator,
+        &mut Graph::always_true_edge_validator,
+        false,
+    );
+    vec_new_node_idx
+}
+
+// todo: we can find downside index node too
+
+fn find_downside_push_node(graph: &Graph, node_idx: Local) -> Vec<Local> {
+    let mut push_node_idxs: Vec<Local> = Vec::new();
+    let def_paths = &DEFPATHS.get().unwrap();
+    // Warning: traverse all downside nodes
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
+        let node = &graph.nodes[idx];
+        for op in node.ops.iter() {
+            if let NodeOp::Call(def_id) = op {
+                if *def_id == def_paths.vec_push.last_def_id() {
+                    push_node_idxs.push(idx);
+                    break;
+                }
+            }
+        }
+        DFSStatus::Continue
+    };
+    graph.dfs(
+        node_idx,
+        Direction::Downside,
+        &mut node_operator,
+        &mut Graph::always_true_edge_validator,
+        true,
+    );
+    push_node_idxs
+}
+
+// Warning: WE APPROXIMATELY VIEW CONST U8s AS SAFE INPUT
+// which may cause wrong result.
+
+// todo: ascii chars are extracted from String variables
+fn value_pushed_is_from_const(graph: &Graph, vec_push_idx: Local) -> bool {
+    let mut const_found = false;
+    let pushed_value_edge = &graph.edges[graph.nodes[vec_push_idx].in_edges[1]]; // The second parameter
+    let pushed_value_idx = pushed_value_edge.src;
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
+        let node = &graph.nodes[idx];
+        for op in node.ops.iter() {
+            if let NodeOp::Const(desc) = op {
+                if desc.contains("u8") {
+                    const_found = true;
+                    return DFSStatus::Stop;
+                }
+            }
+        }
+        DFSStatus::Continue
+    };
+    let mut edge_validator = |graph: &Graph, idx: EdgeIdx| {
+        let edge = &graph.edges[idx];
+        let dst_node = &graph.nodes[edge.dst];
+        match dst_node.in_edges.len() {
+            1 => Graph::always_true_edge_validator(graph, idx),
+            2 => {
+                if let EdgeOp::Index = edge.op {
+                    DFSStatus::Continue
+                } else {
+                    DFSStatus::Stop
+                }
+            }
+            _ => DFSStatus::Stop,
+        }
+    };
+    graph.dfs(
+        pushed_value_idx,
+        Direction::Upside,
+        &mut node_operator,
+        &mut edge_validator,
+        false,
+    );
+    const_found
+}
+
+impl OptCheck for EncodingCheck {
+    fn new() -> Self {
+        Self { record: Vec::new() }
+    }
+
+    fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
+        let _ = &DEFPATHS.get_or_init(|| DefPaths::new(tcx));
+        for node in graph.nodes.iter() {
+            if let Some(vec_node_idx) = extract_vec_if_is_string_from(graph, node) {
+                if let Some(vec_new_idx) = find_upside_vec_new_node(graph, vec_node_idx) {
+                    let vec_push_indice = find_downside_push_node(graph, vec_new_idx);
+                    for vec_push_idx in vec_push_indice {
+                        if !value_pushed_is_from_const(graph, vec_push_idx) {
+                            self.record.clear();
+                            return;
+                        }
+                    }
+                    self.record.push(node.span);
+                }
+            }
+        }
+    }
+
+    fn report(&self, graph: &Graph) {
+        for span in self.record.iter() {
+            report_encoding_bug(graph, *span);
+        }
+    }
+}
+
+fn report_encoding_bug(graph: &Graph, span: Span) {
+    let code_source = span_to_source_code(graph.span);
+    let filename = span_to_filename(graph.span);
+    let snippet = Snippet::source(&code_source)
+        .line_start(span_to_line_number(graph.span))
+        .origin(&filename)
+        .fold(true)
+        .annotation(
+            Level::Error
+                .span(relative_pos_range(graph.span, span))
+                .label("Checked here."),
+        );
+    let message = Level::Warning
+        .title("Unnecessary encoding checkings detected")
+        .snippet(snippet);
+    let renderer = Renderer::styled();
+    println!("{}", renderer.render(message));
+}

--- a/rapx/src/analysis/opt/checking/encoding_checking.rs
+++ b/rapx/src/analysis/opt/checking/encoding_checking.rs
@@ -199,7 +199,8 @@ fn report_encoding_bug(graph: &Graph, span: Span) {
         );
     let message = Level::Warning
         .title("Unnecessary encoding checkings detected")
-        .snippet(snippet);
+        .snippet(snippet)
+        .footer(Level::Help.title("Use unsafe APIs."));
     let renderer = Renderer::styled();
     println!("{}", renderer.render(message));
 }

--- a/rapx/src/analysis/opt/checking/encoding_checking/array_encoding.rs
+++ b/rapx/src/analysis/opt/checking/encoding_checking/array_encoding.rs
@@ -1,0 +1,108 @@
+use std::collections::HashSet;
+
+use once_cell::sync::OnceCell;
+
+use rustc_middle::mir::Local;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+use super::{report_encoding_bug, value_is_from_const};
+use crate::analysis::core::dataflow::graph::{EdgeOp, Graph, GraphEdge, GraphNode, NodeOp};
+use crate::analysis::opt::OptCheck;
+use crate::analysis::utils::def_path::DefPath;
+
+static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
+
+struct DefPaths {
+    str_from_utf8: DefPath,
+}
+
+impl DefPaths {
+    pub fn new(tcx: &TyCtxt<'_>) -> Self {
+        Self {
+            str_from_utf8: DefPath::new("std::str::from_utf8", &tcx),
+        }
+    }
+}
+
+pub struct ArrayEncodingCheck {
+    record: Vec<Span>,
+}
+
+fn extract_ancestor_set_if_is_str_from(
+    graph: &Graph,
+    node_idx: Local,
+    node: &GraphNode,
+) -> Option<HashSet<Local>> {
+    let def_paths = DEFPATHS.get().unwrap();
+    for op in node.ops.iter() {
+        if let NodeOp::Call(def_id) = op {
+            if *def_id == def_paths.str_from_utf8.last_def_id() {
+                return Some(graph.collect_ancestor_locals(node_idx, false));
+            }
+        }
+    }
+    None
+}
+
+fn is_valid_index_edge(graph: &Graph, edge: &GraphEdge) -> bool {
+    if let EdgeOp::Index = edge.op {
+        // must be Index edge
+        let dst_node = &graph.nodes[edge.dst];
+        if dst_node.in_edges.len() > 2 {
+            // must be the left value
+            let rvalue_edge_idx = dst_node.in_edges[2];
+            let rvalue_idx = graph.edges[rvalue_edge_idx].src;
+            if value_is_from_const(graph, rvalue_idx) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+impl OptCheck for ArrayEncodingCheck {
+    fn new() -> Self {
+        Self { record: Vec::new() }
+    }
+
+    fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
+        let _ = &DEFPATHS.get_or_init(|| DefPaths::new(tcx));
+        let common_ancestor = graph
+            .edges
+            .iter()
+            .filter_map(|edge| {
+                // 另外这里index必须是左值，且右值必须来自const
+                if is_valid_index_edge(graph, edge) {
+                    Some(graph.collect_ancestor_locals(edge.src, true))
+                } else {
+                    None
+                }
+            })
+            .reduce(|set1, set2| set1.into_iter().filter(|k| set2.contains(k)).collect());
+
+        if let Some(common_ancestor) = common_ancestor {
+            for (node_idx, node) in graph.nodes.iter_enumerated() {
+                if let Some(str_from_ancestor_set) =
+                    extract_ancestor_set_if_is_str_from(graph, node_idx, node)
+                {
+                    if !common_ancestor
+                        .intersection(&str_from_ancestor_set)
+                        .next()
+                        .is_some()
+                    {
+                        self.record.clear();
+                        return;
+                    }
+                    self.record.push(node.span);
+                }
+            }
+        }
+    }
+
+    fn report(&self, graph: &Graph) {
+        for span in self.record.iter() {
+            report_encoding_bug(graph, *span);
+        }
+    }
+}

--- a/rapx/src/analysis/opt/checking/encoding_checking/vec_encoding.rs
+++ b/rapx/src/analysis/opt/checking/encoding_checking/vec_encoding.rs
@@ -1,0 +1,147 @@
+use std::collections::HashSet;
+
+use once_cell::sync::OnceCell;
+
+use rustc_middle::mir::Local;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+use super::{report_encoding_bug, value_is_from_const};
+use crate::analysis::core::dataflow::graph::{DFSStatus, Direction, Graph, GraphNode, NodeOp};
+use crate::analysis::utils::def_path::DefPath;
+
+static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
+
+struct DefPaths {
+    string_from_utf8: DefPath,
+    string_from_utf8_lossy: DefPath,
+    vec_new: DefPath,
+    vec_with_capacity: DefPath,
+    vec_push: DefPath,
+}
+
+impl DefPaths {
+    // only supports push operation (can't support direct assignment)
+    pub fn new(tcx: &TyCtxt<'_>) -> Self {
+        Self {
+            string_from_utf8: DefPath::new("std::string::String::from_utf8", tcx),
+            string_from_utf8_lossy: DefPath::new("std::string::String::from_utf8_lossy", tcx),
+            vec_new: DefPath::new("std::vec::Vec::new", tcx),
+            vec_with_capacity: DefPath::new("std::vec::Vec::with_capacity", tcx),
+            vec_push: DefPath::new("std::vec::Vec::push", tcx),
+        }
+    }
+}
+
+use crate::analysis::opt::OptCheck;
+
+pub struct VecEncodingCheck {
+    record: Vec<Span>,
+}
+
+fn extract_vec_if_is_string_from(graph: &Graph, node: &GraphNode) -> Option<Local> {
+    let def_paths = &DEFPATHS.get().unwrap();
+    for op in node.ops.iter() {
+        if let NodeOp::Call(def_id) = op {
+            if *def_id == def_paths.string_from_utf8.last_def_id()
+                || *def_id == def_paths.string_from_utf8_lossy.last_def_id()
+            {
+                let in_edge = &graph.edges[node.in_edges[0]];
+                return Some(in_edge.src);
+            }
+        }
+    }
+    None
+}
+
+fn find_upside_vec_new_node(graph: &Graph, node_idx: Local) -> Option<Local> {
+    let mut vec_new_node_idx = None;
+    let def_paths = &DEFPATHS.get().unwrap();
+    // Warning: may traverse all upside nodes and the new result will overwrite on the previous result
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
+        let node = &graph.nodes[idx];
+        for op in node.ops.iter() {
+            if let NodeOp::Call(def_id) = op {
+                if *def_id == def_paths.vec_new.last_def_id()
+                    || *def_id == def_paths.vec_with_capacity.last_def_id()
+                {
+                    vec_new_node_idx = Some(idx);
+                    return DFSStatus::Stop;
+                }
+            }
+        }
+        DFSStatus::Continue
+    };
+    let mut seen = HashSet::new();
+    graph.dfs(
+        node_idx,
+        Direction::Upside,
+        &mut node_operator,
+        &mut Graph::always_true_edge_validator,
+        false,
+        &mut seen,
+    );
+    vec_new_node_idx
+}
+
+// todo: we can find downside index node too
+
+fn find_downside_push_node(graph: &Graph, node_idx: Local) -> Vec<Local> {
+    let mut push_node_idxs: Vec<Local> = Vec::new();
+    let def_paths = &DEFPATHS.get().unwrap();
+    // Warning: traverse all downside nodes
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
+        let node = &graph.nodes[idx];
+        for op in node.ops.iter() {
+            if let NodeOp::Call(def_id) = op {
+                if *def_id == def_paths.vec_push.last_def_id() {
+                    push_node_idxs.push(idx);
+                    break;
+                }
+            }
+        }
+        DFSStatus::Continue
+    };
+    let mut seen = HashSet::new();
+    graph.dfs(
+        node_idx,
+        Direction::Downside,
+        &mut node_operator,
+        &mut Graph::always_true_edge_validator,
+        true,
+        &mut seen,
+    );
+    push_node_idxs
+}
+
+impl OptCheck for VecEncodingCheck {
+    fn new() -> Self {
+        Self { record: Vec::new() }
+    }
+
+    fn check(&mut self, graph: &Graph, tcx: &TyCtxt) {
+        let _ = &DEFPATHS.get_or_init(|| DefPaths::new(tcx));
+        for node in graph.nodes.iter() {
+            if let Some(vec_node_idx) = extract_vec_if_is_string_from(graph, node) {
+                if let Some(vec_new_idx) = find_upside_vec_new_node(graph, vec_node_idx) {
+                    let vec_push_indice = find_downside_push_node(graph, vec_new_idx);
+                    for vec_push_idx in vec_push_indice {
+                        let pushed_value_edge = &graph.edges[graph.nodes[vec_push_idx].in_edges[1]]; // The second parameter
+                        let pushed_value_idx = pushed_value_edge.src;
+                        if !value_is_from_const(graph, pushed_value_idx) {
+                            self.record.clear();
+                            return;
+                        }
+                    }
+                    self.record.push(node.span);
+                }
+            }
+        }
+    }
+
+    fn report(&self, graph: &Graph) {
+        for span in self.record.iter() {
+            report_encoding_bug(graph, *span);
+        }
+    }
+}

--- a/rapx/src/analysis/opt/data_collection/unreserved_hash.rs
+++ b/rapx/src/analysis/opt/data_collection/unreserved_hash.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use once_cell::sync::OnceCell;
 
 use rustc_middle::mir::Local;
@@ -67,12 +69,14 @@ fn find_downside_hash_insert_node(graph: &Graph, node_idx: Local) -> Option<Loca
         }
         DFSStatus::Continue
     };
+    let mut seen = HashSet::new();
     graph.dfs(
         node_idx,
         Direction::Downside,
         &mut node_operator,
         &mut Graph::equivalent_edge_validator,
         false,
+        &mut seen,
     );
     hash_insert_node_idx
 }

--- a/rapx/src/analysis/opt/memory_cloning/hash_key_cloning.rs
+++ b/rapx/src/analysis/opt/memory_cloning/hash_key_cloning.rs
@@ -8,7 +8,7 @@ use crate::analysis::core::dataflow::graph::Direction;
 use crate::analysis::opt::OptCheck;
 use rustc_hir::{intravisit, Expr, ExprKind};
 use rustc_middle::mir::Local;
-use rustc_middle::ty::{TyCtxt, TyKind, TypeckResults};
+use rustc_middle::ty::{TyCtxt, TypeckResults};
 use rustc_span::Span;
 use std::collections::HashSet;
 static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();

--- a/rapx/src/analysis/opt/memory_cloning/hash_key_cloning.rs
+++ b/rapx/src/analysis/opt/memory_cloning/hash_key_cloning.rs
@@ -84,12 +84,14 @@ fn find_first_param_upside_clone(graph: &Graph, node: &GraphNode) -> Option<Loca
         }
         DFSStatus::Continue
     };
+    let mut seen = HashSet::new();
     graph.dfs(
         graph.edges[node.in_edges[1]].src, // the first param is self, so we use 1
         Direction::Upside,
         &mut node_operator,
         &mut Graph::equivalent_edge_validator,
         false,
+        &mut seen,
     );
     clone_node_idx
 }
@@ -114,12 +116,14 @@ fn find_hash_new_node(graph: &Graph, node: &GraphNode) -> Option<Local> {
         }
         DFSStatus::Continue
     };
+    let mut seen = HashSet::new();
     graph.dfs(
         graph.edges[node.in_edges[0]].src, // the first param is self
         Direction::Upside,
         &mut node_operator,
         &mut Graph::equivalent_edge_validator,
         false,
+        &mut seen,
     );
     new_node_idx
 }

--- a/rapx/src/analysis/opt/memory_cloning/used_as_immutable.rs
+++ b/rapx/src/analysis/opt/memory_cloning/used_as_immutable.rs
@@ -11,6 +11,7 @@ use rustc_middle::mir::Local;
 use rustc_middle::ty::{TyCtxt, TyKind};
 use rustc_span::Span;
 use std::cell::Cell;
+use std::collections::HashSet;
 static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
 
 use crate::analysis::core::dataflow::graph::Graph;
@@ -53,12 +54,14 @@ fn find_downside_use_as_param(graph: &Graph, clone_node_idx: Local) -> Option<(L
         edge_idx.set(idx);
         Graph::equivalent_edge_validator(graph, idx)
     };
+    let mut seen = HashSet::new();
     graph.dfs(
         clone_node_idx,
         Direction::Downside,
         &mut node_operator,
         &mut edge_operator,
         true,
+        &mut seen,
     );
     record
 }

--- a/rapx/tests/others/todo/bounds_extend/Cargo.toml
+++ b/rapx/tests/others/todo/bounds_extend/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "bounds_extend"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rapx/tests/others/todo/bounds_extend/src/lib.rs
+++ b/rapx/tests/others/todo/bounds_extend/src/lib.rs
@@ -1,0 +1,3 @@
+fn foo(buf1: &mut Vec<u8>, buf2: &[u8]) {
+    buf1.extend_from_slice(&buf2);
+}

--- a/rapx/tests/others/todo/encoding_check/Cargo.toml
+++ b/rapx/tests/others/todo/encoding_check/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "encoding_check"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rapx/tests/others/todo/encoding_check/src/lib.rs
+++ b/rapx/tests/others/todo/encoding_check/src/lib.rs
@@ -1,0 +1,27 @@
+use std::str;
+
+fn foo_1(mut n: u128, base: usize, output: &mut String) {
+    const BASE_64: &[u8; 64] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@$";
+    let mut s = [0u8; 128];
+    let mut index = s.len();
+    let base = base as u128;
+    loop {
+        index -= 1;
+        s[index] = BASE_64[(n % base) as usize];
+        n /= base;
+        if n == 0 {
+            break;
+        }
+    }
+    output.push_str(str::from_utf8(&s[index..]).unwrap());
+}
+
+static CHARS: &[u8; 5] = b"12345";
+
+fn foo_2() -> String {
+    let mut v = Vec::with_capacity(12);
+    v.push(CHARS[2 as usize]);
+    v.push(CHARS[3 as usize]);
+    v.push(b' ');
+    String::from_utf8_lossy(&v).to_string()
+}


### PR DESCRIPTION
- Add detection code of utf8 encoding (String created from Vec or Array)
- Fix bugs, including
  - Infinite recursion caused by `rings` in the dataflow graph
  - Debug error caused by marker nodes with `Use` NodeOp. Usually shows up in `_a[_b]=rvalue`. The left value creates a marker node and the assignment gives it `Use` op.
