### PR TITLE
sort alias index & update sp json

### DIFF
--- a/rapx/src/analysis/core/alias.rs
+++ b/rapx/src/analysis/core/alias.rs
@@ -40,6 +40,26 @@ impl FnRetAlias {
     pub fn len(&self) -> usize {
         self.alias_set.len()
     }
+
+    pub fn sort_alias_index(&mut self) {
+        let alias_set = std::mem::take(&mut self.alias_set);
+        let mut new_alias_set = HashSet::with_capacity(alias_set.len());
+
+        for mut ra in alias_set.into_iter() {
+            if ra.left_index >= ra.right_index {
+                Self::swap_ret_alias_fields(&mut ra);
+            }
+            new_alias_set.insert(ra);
+        }
+        self.alias_set = new_alias_set;
+    }
+
+    pub fn swap_ret_alias_fields(ra: &mut RetAlias) {
+        std::mem::swap(&mut ra.left_index, &mut ra.right_index);
+        std::mem::swap(&mut ra.left_field_seq, &mut ra.right_field_seq);
+        std::mem::swap(&mut ra.left_may_drop, &mut ra.right_may_drop);
+        std::mem::swap(&mut ra.left_need_drop, &mut ra.right_need_drop);
+    }
 }
 
 impl fmt::Display for FnRetAlias {

--- a/rapx/src/analysis/core/alias/mop.rs
+++ b/rapx/src/analysis/core/alias/mop.rs
@@ -39,8 +39,9 @@ impl<'tcx> MopAlias<'tcx> {
             }
         }
         // Meaning of output: 0 for ret value; 1,2,3,... for corresponding args.
-        for (fn_id, fn_alias) in &self.fn_map {
+        for (fn_id, fn_alias) in &mut self.fn_map {
             let fn_name = get_fn_name(self.tcx, *fn_id);
+            fn_alias.sort_alias_index();
             if fn_alias.len() > 0 {
                 rap_info!("Alias found in {:?}: {}", fn_name, fn_alias);
             }

--- a/rapx/src/analysis/safedrop/graph.rs
+++ b/rapx/src/analysis/safedrop/graph.rs
@@ -611,11 +611,9 @@ impl<'tcx> SafeDropGraph<'tcx> {
     }
 
     pub fn get_paths(&self) -> Vec<Vec<usize>> {
-        // rap_debug!("dfs here");
         let mut paths: Vec<Vec<usize>> = Vec::new();
         let mut stack: Vec<usize> = vec![0];
         self.dfs_on_spanning_tree(0, &mut stack, &mut paths);
-
         paths
     }
 

--- a/rapx/src/analysis/senryx.rs
+++ b/rapx/src/analysis/senryx.rs
@@ -194,16 +194,15 @@ impl<'tcx> SenryxCheck<'tcx> {
         for check_result in &check_results {
             cond_print!(
                 check_result.failed_contracts.len() > 0,
-                "  Unsafe api {:?}: {} passed, {} failed!",
-                check_result.func_name,
-                check_result.passed_contracts.len(),
-                check_result.failed_contracts.len()
+                "  Use unsafe api {:?}.",
+                check_result.func_name
             );
             for failed_contract in &check_result.failed_contracts {
                 cond_print!(
                     check_result.failed_contracts.len() > 0,
-                    "      Contract failed: {:?}",
-                    failed_contract
+                    "      Argument {}'s failed Sps: {:?}",
+                    failed_contract.0,
+                    failed_contract.1
                 );
             }
         }

--- a/rapx/src/analysis/unsafety_isolation/data/std_sps.json
+++ b/rapx/src/analysis/unsafety_isolation/data/std_sps.json
@@ -1,92 +1,92 @@
 {
     "core::alloc::global::GlobalAlloc::alloc": {
       "0": [
-        "ValidInt",
+        "ValidNum",
         "Init"
       ]
     },
     "core::alloc::global::GlobalAlloc::realloc": {
       "0": [
         "Allocated",
-        "LayoutConsistency",
-        "ValidInt"
+        "Layout",
+        "ValidNum"
       ]
     },
     "core::alloc::global::GlobalAlloc::dealloc": {
       "0": [
         "Allocated",
-        "LayoutConsistency"
+        "Layout"
       ]
     },
     "core::alloc::global::GlobalAlloc::alloc_zeroed": {
       "0": [
-        "ValidInt"
+        "ValidNum"
       ]
     },
     "core::alloc::layout::from_size_align_unchecked": {
       "0": [
-        "ValidInt"
+        "ValidNum"
       ]
     },
     "core::alloc::layout::for_value_raw": {
         "0": [
-          "Sized",
-          "!Sized && ValidSlice",
-          "!Sized && ValidTraitObj"
+          "Size",
+          "ValidSlice",
+          "ValidTraitObj"
         ]
       },
     "core::alloc::Allocator::grow": {
       "0": [
         "Allocated",
-        "LayoutConsistency",
-        "ValidInt"
+        "Layout",
+        "ValidNum"
       ]
     },
     "core::alloc::Allocator::grow_zeroed": {
       "0": [
         "Allocated",
-        "LayoutConsistency",
-        "ValidInt"
+        "Layout",
+        "ValidNum"
       ]
     },
     "core::alloc::Allocator::shrink": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "core::alloc::Allocator::deallocate": {
         "0": [
             "Allocated",
-            "LayoutConsistency"
+            "Layout"
         ]
     },
     "core::alloc::deallocate": {
         "0": [
             "Allocated",
-            "LayoutConsistency"
+            "Layout"
         ]
     },
     "core::alloc::grow": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "core::alloc::grow_zeroed": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "core::alloc::shrink": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "core::any::downcast_ref_unchecked": {
@@ -101,23 +101,23 @@
     },
     "core::array::iter::new_unchecked": {
         "0": [
-            "ValidInt",
+            "ValidNum",
             "Init"
         ]
     },
     "core::array::ascii::as_ascii_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ascii::ascii_char::digit_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ascii::ascii_char::from_u8_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::cell::try_borrow_unguarded": {
@@ -142,41 +142,41 @@
     },
     "core::f128::to_int_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::f64::to_int_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::f32::to_int_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::f16::to_int_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::convert::num::FloatToInt::to_int_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::convert::num::to_int_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ffi::c_str::from_ptr": {
         "0": [
             "ValidCStr",
             "ValidPtr",
-            "NonNull",
+            "!Null",
             "Alias",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ffi::c_str::from_bytes_with_nul_unchecked": {
@@ -188,28 +188,28 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonNull",
-            "Dangling"
+            "!Null",
+            "Allocated"
         ]
     },
     "core::iter::range::forward_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::iter::range::backward_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::iter::range::Step::forward_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::iter::range::Step::backward_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::mem::manually_drop::take": {
@@ -219,7 +219,7 @@
     },
     "core::mem::manually_drop::drop": {
         "0": [
-            "Dangling"
+            "Allocated"
         ]
     },
     "core::mem::maybe_uninit::assume_init": {
@@ -236,7 +236,7 @@
     "core::mem::maybe_uninit::assume_init_drop": {
         "0": [
             "Init",
-            "Dangling"
+            "Allocated"
         ]
     },
     "core::mem::maybe_uninit::assume_init_ref": {
@@ -266,16 +266,16 @@
     },
     "core::mem::size_of_val_raw": {
         "0": [
-            "Sized",
-            "!Sized && ValidSlice",
-            "!Sized && ValidTraitObj"
+            "Size",
+            "ValidSlice",
+            "ValidTraitObj"
         ]
     },
     "core::mem::align_of_val_raw": {
         "0": [
-            "Sized",
-            "!Sized && ValidSlice",
-            "!Sized && ValidTraitObj"
+            "Size",
+            "ValidSlice",
+            "ValidTraitObj"
         ]
     },
     "core::mem::zeroed": {
@@ -285,7 +285,7 @@
     },
     "core::mem::uninitialized": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::mem::transmute_copy": {
@@ -302,62 +302,62 @@
     },
     "core::num::nonzero::unchecked_add": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::nonzero::unchecked_mul": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::nonzero::new_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::nonzero::from_mut_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::unchecked_sub": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::unchecked_mul": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::unchecked_neg": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::unchecked_shl": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::unchecked_shr": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::num::unchecked_add": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::hint::unreachable_unchecked": {
         "0": [
-            "ValidInt"
+            "Unreachable"
         ]
     },
     "core::hint::assert_unchecked": {
         "0": [
-            "Unreachable"
+            "ValidNum"
         ]
     },
     "core::pin::map_unchecked": {
@@ -390,12 +390,12 @@
             "ValidPtr",
             "Aligned",
             "Alias",
-            "Lifetime"
+            "Alive"
         ]
     },
     "core::intrinsics::float_to_int_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::intrinsics::typed_swap": {
@@ -408,7 +408,7 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonVolatile",
+            "!Volatile",
             "Alias",
             "CopyTrait"
         ]
@@ -417,14 +417,14 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonVolatile",
+            "!Volatile",
             "Alias",
             "CopyTrait"
         ],
         "1": [
             "ValidPtr",
             "Aligned",
-            "NonVolatile",
+            "!Volatile",
             "Alias",
             "CopyTrait"
         ]
@@ -434,7 +434,7 @@
             "ValidPtr",
             "Aligned",
             "NonOverlap",
-            "NonVolatile",
+            "!Volatile",
             "Alias",
             "CopyTrait"
         ],
@@ -442,7 +442,7 @@
             "ValidPtr",
             "Aligned",
             "NonOverlap",
-            "NonVolatile",
+            "!Volatile",
             "Alias",
             "CopyTrait"
         ]
@@ -457,24 +457,24 @@
     "core::intrinsics::ptr_offset_from": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::alignment::new_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::non_null::as_uninit_ref": {
         "0": [
-            "!NonNull | ",
+            "!Null | ",
             "ValidPtr2Ref"
         ]
     },
     "core::ptr::non_null::as_uninit_mut": {
         "0": [
-            "!NonNull | ",
+            "!Null | ",
             "ValidPtr2Ref"
         ]
     },
@@ -485,7 +485,7 @@
     },
     "core::ptr::non_null::as_ref": {
         "0": [
-            "!NonNull | ",
+            "!Null | ",
             "ValidPtr2Ref"
         ]
     },
@@ -497,58 +497,58 @@
     "core::ptr::non_null::offset": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::non_null::add": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::non_null::byte_offset": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::non_null::byte_add": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::non_null::byte_sub": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::non_null::offset_from": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::non_null::byte_offset_from": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::non_null::sub_ptr": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::non_null::sub": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::non_null::read": {
@@ -578,7 +578,7 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonVolatile",
+            "!Volatile",
             "Alias",
             "CopyTrait"
         ]
@@ -588,7 +588,7 @@
             "ValidPtr",
             "Aligned",
             "NonOverlap",
-            "NonVolatile",
+            "!Volatile",
             "CopyTrait",
             "Alias"
         ]
@@ -597,7 +597,7 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonVolatile",
+            "!Volatile",
             "CopyTrait",
             "Alias"
         ]
@@ -607,7 +607,7 @@
             "ValidPtr",
             "Aligned",
             "NonOverlap",
-            "NonVolatile",
+            "!Volatile",
             "CopyTrait",
             "Alias"
         ]
@@ -615,8 +615,7 @@
     "core::ptr::non_null::drop_in_place": {
         "0": [
             "ValidPtr",
-            "Aligned",
-            "NonNull"
+            "Aligned"
         ]
     },
     "core::ptr::non_null::write": {
@@ -658,38 +657,36 @@
     },
     "core::ptr::non_null::as_uninit_slice": {
         "0": [
-            "!NonNull ||",
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned"
         ]
     },
     "core::ptr::non_null::as_uninit_slice_mut": {
         "0": [
-            "!NonNull ||",
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned"
         ]
     },
     "core::ptr::non_null::get_unchecked_mut": {
         "0": [
-            "ValidInt",
-            "Dangling"
+            "ValidNum",
+            "Allocated"
         ]
     },
 
     "core::ptr::const_ptr::as_ref": {
         "0": [
-            "!NonNull | ",
+            "!Null | ",
             "ValidPtr2Ref"
         ]
     },
@@ -700,72 +697,72 @@
     },
     "core::ptr::const_ptr::as_uninit_ref": {
         "0": [
-            "!NonNull | ",
+            "!Null | ",
             "ValidPtr2Ref"
         ]
     },
     "core::ptr::const_ptr::offset": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::const_ptr::add": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::const_ptr::sub": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::const_ptr::byte_offset": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::const_ptr::offset_from": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::const_ptr::byte_offset_from": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::const_ptr::non_null::sub_ptr": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::const_ptr::sub_ptr": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::const_ptr::byte_add": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::const_ptr::byte_sub": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::const_ptr::read": {
@@ -795,7 +792,7 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonVolatile",
+            "!Volatile",
             "Alias",
             "CopyTrait"
         ]
@@ -805,27 +802,26 @@
             "ValidPtr",
             "Aligned",
             "NonOverlap",
-            "NonVolatile",
+            "!Volatile",
             "CopyTrait",
             "Alias"
         ]
     },
     "core::ptr::const_ptr::as_uninit_slice": {
         "0": [
-            "!NonNull ||",
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned"
         ]
     },
     "core::ptr::const_ptr::get_unchecked": {
         "0": [
-            "ValidInt",
-            "Dangling"
+            "ValidNum",
+            "Allocated"
         ]
     },
 
@@ -833,7 +829,7 @@
 
     "core::ptr::mut_ptr::as_ref": {
         "0": [
-            "!NonNull | ",
+            "!Null | ",
             "ValidPtr2Ref"
         ]
     },
@@ -844,14 +840,14 @@
     },
     "core::ptr::mut_ptr::as_uninit_ref": {
         "0": [
-            "!NonNull | ",
+            "!Null | ",
             "ValidPtr2Ref"
         ]
     },
     "core::ptr::mut_ptr::offset": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::mut_ptr::as_mut": {
@@ -866,59 +862,59 @@
     },
     "core::ptr::mut_ptr::as_uninit_mut": {
         "0": [
-            "!NonNull | ",
+            "!Null | ",
             "ValidPtr2Ref"
         ]
     },
     "core::ptr::mut_ptr::add": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::mut_ptr::sub": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::mut_ptr::byte_offset": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::mut_ptr::offset_from": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::mut_ptr::byte_offset_from": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::mut_ptr::sub_ptr": {
         "0": [
             "InBounded",
-            "ValidInt",
-            "!ZST"
+            "ValidNum",
+            "!Size"
         ]
     },
     "core::ptr::mut_ptr::byte_add": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::mut_ptr::byte_sub": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::ptr::mut_ptr::read": {
@@ -948,7 +944,7 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonVolatile",
+            "!Volatile",
             "Alias",
             "CopyTrait"
         ]
@@ -958,7 +954,7 @@
             "ValidPtr",
             "Aligned",
             "NonOverlap",
-            "NonVolatile",
+            "!Volatile",
             "CopyTrait",
             "Alias"
         ]
@@ -967,7 +963,7 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonVolatile",
+            "!Volatile",
             "CopyTrait",
             "Alias"
         ]
@@ -977,7 +973,7 @@
             "ValidPtr",
             "Aligned",
             "NonOverlap",
-            "NonVolatile",
+            "!Volatile",
             "CopyTrait",
             "Alias"
         ]
@@ -986,7 +982,7 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonNull"
+            "!Null"
         ]
     },
     "core::ptr::mut_ptr::write": {
@@ -1028,44 +1024,43 @@
     },
     "core::ptr::mut_ptr::split_at_mut": {
         "0": [
-            "ValidInt",
-            "Dangling"
+            "ValidNum",
+            "Allocated"
         ]
     },
     "core::ptr::mut_ptr::split_at_mut_unchecked": {
         "0": [
-            "ValidInt",
-            "Dangling"
+            "ValidNum",
+            "Allocated"
         ]
     },
     "core::ptr::mut_ptr::as_uninit_slice": {
         "0": [
-            "!NonNull ||",
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned"
         ]
     },
     "core::ptr::mut_ptr::as_uninit_slice_mut": {
         "0": [
-            "!NonNull ||",
-            "NonNull",
+
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned"
         ]
     },
     "core::ptr::mut_ptr::get_unchecked_mut": {
         "0": [
-            "ValidInt",
-            "Dangling"
+            "ValidNum",
+            "Allocated"
         ]
     },
 
@@ -1073,7 +1068,7 @@
         "0": [
             "ValidPtr",
             "Aligned",
-            "NonNull"
+            "!Null"
         ]
     },
     "core::ptr::replace": {
@@ -1139,7 +1134,7 @@
     "core::ptr::offset": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::clone::clone_to_uninit": {
@@ -1173,13 +1168,13 @@
     "core::slice::index::SliceIndex::get_unchecked": {
         "0": [
             "InBounded",
-            "Dangling"
+            "Allocated"
         ]
     },
     "core::slice::index::SliceIndex::get_unchecked_mut": {
         "0": [
             "InBounded",
-            "Dangling"
+            "Allocated"
         ]
     },
     "core::slice::get_unchecked_mut": {
@@ -1194,14 +1189,12 @@
     },
     "core::slice::as_chunks_unchecked": {
         "0": [
-            "ValidInt",
-            "?"
+            "ValidNum"
         ]
     },
     "core::slice::as_chunks_unchecked_mut": {
         "0": [
-            "ValidInt",
-            "?"
+            "ValidNum"
         ]
     },
     "core::slice::split_at_unchecked": {
@@ -1229,68 +1222,64 @@
     },
     "core::slice::ascii::as_ascii_unchecked": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::slice::raw::from_raw_parts": {
         "0":[
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "Aligned"
-        ],
-        "1": [
-            "ValidInt"
+            "Aligned",
+            "ValidNum"
         ]
     },
     "core::slice::raw::from_raw_parts_mut": {
         "0":[
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "Aligned"
-        ],
-        "1": [
-            "ValidInt"
+            "Aligned",
+            "ValidNum"
         ]
     },
     "core::slice::index::get_unchecked": {
         "0": [
-            "Dangling",
+            "Allocated",
             "InBounded"
         ]
     },
     "core::slice::index::get_unchecked_mut": {
         "0": [
-            "Dangling",
+            "Allocated",
             "InBounded"
         ]
     },
     "core::slice::raw::from_ptr_range": {
         "0": [
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned",
             "InBounded",
-            "!ZST"
+            "!Size"
         ]
     },
     "core::slice::raw::from_mut_ptr_range": {
         "0": [
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned"
         ]
     },
@@ -1335,23 +1324,23 @@
     },
     "core::str::converts::from_raw_parts": {
         "0": [
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned"
         ]
     },
     "core::str::converts::from_raw_parts_mut": {
         "0": [
-            "NonNull",
+            "!Null",
             "ValidPtr",
             "Init",
-            "Lifetime",
+            "Alive",
             "Alias",
-            "ValidInt",
+            "ValidNum",
             "Aligned"
         ]
     },
@@ -1385,7 +1374,7 @@
     "core::task::wake::from_raw": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
 
@@ -1394,8 +1383,8 @@
             "Allocated",
             "Aligned",
             "InBounded",
-            "ValidInt",
-            "LayoutConsistency"
+            "ValidNum",
+            "Layout"
         ]
     },
     "alloc::vec::from_parts": {
@@ -1403,8 +1392,8 @@
             "Allocated",
             "Aligned",
             "InBounded",
-            "ValidInt",
-            "LayoutConsistency"
+            "ValidNum",
+            "Layout"
         ]
     },
     "alloc::vec::from_raw_parts_in": {
@@ -1412,8 +1401,8 @@
             "Allocated",
             "Aligned",
             "InBounded",
-            "ValidInt",
-            "LayoutConsistency"
+            "ValidNum",
+            "Layout"
         ]
     },
     "alloc::vec::from_parts_in": {
@@ -1421,65 +1410,65 @@
             "Allocated",
             "Aligned",
             "InBounded",
-            "ValidInt",
-            "LayoutConsistency"
+            "ValidNum",
+            "Layout"
         ]
     },
     "alloc::vec::set_len": {
         "0": [
             "InBounded",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "alloc::alloc::alloc": {
         "0": [
-            "ValidInt",
+            "ValidNum",
             "Init"
         ]
     },
     "alloc::alloc::dealloc": {
         "0": [
             "Allocated",
-            "LayoutConsistency"
+            "Layout"
         ]
     },
     "alloc::alloc::realloc": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "alloc::alloc::alloc_zeroed": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "alloc::alloc::deallocate": {
         "0": [
             "Allocated",
-            "LayoutConsistency"
+            "Layout"
         ]
     },
     "alloc::alloc::grow": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "alloc::alloc::grow_zeroed": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "alloc::alloc::shrink": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "alloc::boxed::assume_init": {
@@ -1518,26 +1507,22 @@
     },
     "alloc::collections::btree::map::insert_after_unchecked": {
         "0": [
-            "",
-            ""
+            "Function_sp"
         ]
     },
     "alloc::collections::btree::map::insert_before_unchecked": {
         "0": [
-            "",
-            ""
+            "Function_sp"
         ]
     },
     "alloc::collections::btree::set::insert_after_unchecked": {
         "0": [
-            "",
-            ""
+            "Function_sp"
         ]
     },
     "alloc::collections::btree::set::insert_before_unchecked": {
         "0": [
-            "",
-            ""
+            "Function_sp"
         ]
     },
     "alloc::ffi::c_str::from_vec_unchecked": {
@@ -1571,13 +1556,13 @@
     "alloc::rc::increment_strong_count": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
     "alloc::rc::decrement_strong_count": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
     "alloc::rc::from_raw_in": {
@@ -1590,13 +1575,13 @@
     "alloc::rc::increment_strong_count_in": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
     "alloc::rc::decrement_strong_count_in": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
     "alloc::rc::downcast_unchecked": {
@@ -1612,14 +1597,12 @@
     },
     "alloc::collections::btree::map::with_mutable_key": {
         "0": [
-            "",
-            ""
+            "Function_sp"
         ]
     },
     "alloc::collections::btree::set::upper_bound_mut": {
         "0": [
-            "",
-            ""
+            "Function_sp"
         ]
     },
     "alloc::str::from_boxed_utf8_unchecked": {
@@ -1631,7 +1614,7 @@
         "0": [
             "Allocated",
             "Aligned",
-            "ValidInt",
+            "ValidNum",
             "ValidString"
         ]
     },
@@ -1660,13 +1643,13 @@
     "alloc::sync::increment_strong_count": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
     "alloc::sync::decrement_strong_count": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
     "alloc::sync::from_raw_in": {
@@ -1679,13 +1662,13 @@
     "alloc::sync::increment_strong_count_in": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
     "alloc::sync::decrement_strong_count_in": {
         "0": [
             "Allocated",
-            "Dangling"
+            "Allocated"
         ]
     },
     "alloc::sync::downcast_unchecked": {
@@ -1706,12 +1689,12 @@
     },
     "std::env::set_var": {
         "0": [
-            ""
+            "System_sp"
         ]
     },
     "std::env::remove_var": {
         "0": [
-            ""
+            "System_sp"
         ]
     },
     "std::ffi::os_str::from_encoded_bytes_unchecked": {
@@ -1742,12 +1725,12 @@
     },
     "std::os::unix::process::CommandExt::before_exec": {
         "0": [
-            ""
+            "System_sp"
         ]
     },
     "std::os::unix::process::pre_exec": {
         "0": [
-            ""
+            "System_sp"
         ]
     },
     "std::os::unix::process::from_raw_fd": {
@@ -1768,7 +1751,7 @@
     "std::os::fd::owned::borrow_raw": {
         "0": [
             "Opened",
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "std::os::fd::owned::from_raw_fd": {
@@ -1819,7 +1802,7 @@
     },
     "std::sys::pal::unix::process::process_common::pre_exec": {
         "0": [
-            ""
+            "System_sp"
         ]
     },
     "std::sys::anonymous_pipe::unix::from_raw_fd": {
@@ -1833,107 +1816,81 @@
             "Aligned"
         ]
     },
-    "std::alloc::System::deallocate": {
-        "0": [
-            "Allocated",
-            "LayoutConsistency"
-        ]
-    },
-    "std::alloc::System::grow": {
-        "0": [
-            "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
-        ]
-    },
-    "std::alloc::System::grow_zeroed": {
-        "0": [
-            "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
-        ]
-    },
-    "std::alloc::System::shrink": {
-        "0": [
-            "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
-        ]
-    },
     "std::alloc::deallocate": {
         "0": [
             "Allocated",
-            "LayoutConsistency"
+            "Layout"
         ]
     },
     "std::alloc::grow": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "std::alloc::grow_zeroed": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "std::alloc::shrink": {
         "0": [
             "Allocated",
-            "LayoutConsistency",
-            "ValidInt"
+            "Layout",
+            "ValidNum"
         ]
     },
     "std::raw_attribute": {
         "0": [
-            "Lifetime",
-            "ValidInt"
+            "Alive",
+            "ValidNum"
         ]
     },
     "std::from_raw_handle": {
         "0": [
-            "Opened",
-            "ValidFreed"
+            "Opened"
         ]
     },
     "std::thread::spawn_unchecked": {
         "0": [
-            "Lifetime",
+            "Alive",
             "Init",
-            ""
+            "Function_sp"
         ]
     },
     "core::intrinsics::const_allocate": {
         "0": [
-            "ValidInt"
+            "ValidNum"
         ]
     },
     "core::intrinsics::assume": {
         "0": [
-            ""
+            "ValidNum"
         ]
     },
     "core::intrinsics::drop_in_place": {
         "0": [
-            ""
+            "ValidPtr",
+            "Aligned",
+            "!Null"
         ]
     },
     "core::intrinsics::const_deallocate": {
         "0": [
-            ""
+            "ValidNum"
         ]
     },
     "core::intrinsics::vtable_size": {
         "0": [
-            ""
+            "ValidPtr"
         ]
     },
     "core::intrinsics::vtable_align": {
         "0": [
-            ""
+            "ValidPtr"
         ]
     },
     "core::intrinsics::pref_align_of": {
@@ -1943,12 +1900,16 @@
     },
     "core::intrinsics::size_of_val": {
         "0": [
-            ""
+            "Size",
+            "ValidSlice",
+            "ValidTraitObj"
         ]
     },
     "core::intrinsics::min_align_of_val": {
         "0": [
-            ""
+            "Size",
+            "ValidSlice",
+            "ValidTraitObj"
         ]
     },
     "core::ffi::va_list::arg": {
@@ -1963,12 +1924,12 @@
     },
     "core::task::wake::new": {
         "0": [
-            ""
+            "System_sp"
         ]
     },
     "alloc::collections::btree::set::with_mutable_key": {
         "0": [
-            ""
+            "Function_sp"
         ]
     },
     "alloc::sync::assume_init": {
@@ -1978,7 +1939,7 @@
     },
     "std::sys::os_str::bytes::from_encoded_bytes_unchecked": {
         "0": [
-            ""
+            "ValidString"
         ]
     }
 }  

--- a/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
+++ b/rapx/src/analysis/unsafety_isolation/std_unsafety_isolation.rs
@@ -1,17 +1,16 @@
 use crate::analysis::utils::fn_info::*;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
-use rustc_hir::def_id::CRATE_DEF_INDEX;
 use rustc_middle::ty::Visibility;
 use rustc_middle::{ty, ty::TyCtxt};
 use std::collections::HashMap;
 use std::collections::HashSet;
 // use crate::analysis::unsafety_isolation::draw_dot::render_dot_graphs;
-
 use super::{
     generate_dot::{NodeType, UigUnit},
     UnsafetyIsolationCheck,
 };
+use rustc_middle::mir::Local;
 
 impl<'tcx> UnsafetyIsolationCheck<'tcx> {
     pub fn handle_std_unsafe(&mut self) {
@@ -20,43 +19,16 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         let mut dot_strs = Vec::new();
         for uig in &self.uigs {
             let dot_str = uig.generate_dot_str();
-            // uig.compare_labels(self.tcx);
             dot_strs.push(dot_str);
         }
         for uig in &self.single {
             let dot_str = uig.generate_dot_str();
-            // uig.compare_labels(self.tcx);
             dot_strs.push(dot_str);
+            // println!("{:?}", get_cleaned_def_path_name(self.tcx, uig.caller.0));
         }
+        // println!("single {:?}",self.uigs.len());
         // println!("single {:?}",self.single.len());
         // render_dot_graphs(dot_strs);
-    }
-
-    pub fn get_all_std_unsafe_def_id_by_rustc_extern_crates(
-        &mut self,
-        tcx: TyCtxt<'tcx>,
-    ) -> HashSet<DefId> {
-        let mut visited = HashSet::new();
-        let mut unsafe_fn = HashSet::new();
-        for &crate_num in tcx.crates(()).iter() {
-            let crate_name = tcx.crate_name(crate_num).to_string();
-            // if crate_name == "std" || crate_name == "core" || crate_name == "alloc" {
-            if crate_name == "core" {
-                let crate_root = DefId {
-                    krate: crate_num,
-                    index: CRATE_DEF_INDEX,
-                };
-                self.process_def_id(tcx, crate_root, &mut visited, &mut unsafe_fn);
-                println!(
-                    "{:?} has {:?} MIR instances totally, with {:?} unsafe fns.",
-                    crate_name,
-                    visited.len(),
-                    unsafe_fn.len()
-                );
-            }
-        }
-        // Self::print_hashset(&unsafe_fn);
-        unsafe_fn
     }
 
     pub fn get_all_std_unsafe_def_id_by_treat_std_as_local_crate(
@@ -64,6 +36,9 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         tcx: TyCtxt<'tcx>,
     ) -> HashSet<DefId> {
         let mut unsafe_fn = HashSet::new();
+        let mut total_cnt = 0;
+        let mut api_cnt = 0;
+        let mut sp_cnt = 0;
         let def_id_sets = tcx.mir_keys(());
         let mut sp_count_map: HashMap<String, usize> = HashMap::new();
 
@@ -72,70 +47,182 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
             if Self::filter_mir(def_id) {
                 continue;
             }
-            if tcx.def_kind(def_id) == DefKind::Fn || tcx.def_kind(def_id) == DefKind::AssocFn {
-                // if Self::check_safety(tcx, def_id)
-                //     && Self::check_visibility(tcx, def_id)
-                if check_visibility(tcx, def_id) {
-                    if check_safety(tcx, def_id) {
-                        let sp_set = get_sp(tcx, def_id);
-                        if sp_set.len() != 0 {
-                            unsafe_fn.insert(def_id);
-                            // println!("unsafe fn : {:?}", UigUnit::get_cleaned_def_path_name(self.tcx, def_id));
-                        }
-                        for sp in sp_set {
-                            *sp_count_map.entry(sp).or_insert(0) += 1;
+            if get_cleaned_def_path_name(self.tcx, def_id).contains("UdpSocket") {
+                println!("1");
+                let impl_vec = get_impls_for_struct(self.tcx, def_id);
+                for impl_id in impl_vec {
+                    println!("2");
+
+                    let associated_items = tcx.associated_items(impl_id);
+                    for item in associated_items.in_definition_order() {
+                        if let ty::AssocKind::Fn = item.kind {
+                            let item_def_id = item.def_id;
+                            println!("method {:?}", item_def_id);
                         }
                     }
-                    self.insert_uig(def_id, get_callees(tcx, def_id), get_cons(tcx, def_id));
                 }
+            }
+            if tcx.def_kind(def_id) == DefKind::Fn || tcx.def_kind(def_id) == DefKind::AssocFn {
+                if check_safety(tcx, def_id)
+                    && !get_cleaned_def_path_name(self.tcx, def_id).contains("intrinsic")
+                {
+                    // if get_cleaned_def_path_name(self.tcx, def_id).contains("std::") {
+                    //     println!("{:?}", get_cleaned_def_path_name(self.tcx, def_id));
+                    // }
+                    let sp_set = get_sp(tcx, def_id);
+                    if sp_set.len() != 0 {
+                        unsafe_fn.insert(def_id);
+                        let mut flag = false;
+                        for sp in &sp_set {
+                            if sp == ""
+                                || sp == "Function_sp"
+                                || sp == "System_sp"
+                                || sp == "ValidSlice"
+                            {
+                                flag = true;
+                            }
+                        }
+                        if flag == false {
+                            api_cnt += 1;
+                            sp_cnt += sp_set.len();
+                        }
+                        total_cnt += 1;
+                        // println!("unsafe fn : {:?}", get_cleaned_def_path_name(self.tcx, def_id));
+                    }
+                    for sp in sp_set {
+                        *sp_count_map.entry(sp).or_insert(0) += 1;
+                    }
+                    // self.check_params(def_id);
+                }
+                self.insert_uig(def_id, get_callees(tcx, def_id), get_cons(tcx, def_id));
             }
         }
         self.analyze_struct();
         // self.analyze_uig();
+        // self.get_units_data(self.tcx);
         // for (sp, count) in &sp_count_map {
         //     println!("SP: {}, Count: {}", sp, count);
         // }
-        // println!("uig and single len : {:?} and {:?}", self.uigs.len(), self.single.len());
+        println!(
+            "count : {:?} and {:?}, sp cnt : {}",
+            total_cnt, api_cnt, sp_cnt
+        );
         // println!("unsafe fn len {}", unsafe_fn.len());
         unsafe_fn
     }
 
-    pub fn analyze_uig(&self) {
-        let mut pro1 = Vec::new();
-        let mut enc1 = Vec::new();
-        for uig in &self.uigs {
-            if uig.caller.1 != true && uig.caller.2 == 2 {
-                enc1.push(uig.clone());
-            } else if uig.caller.1 == true && uig.caller.2 == 2 {
-                pro1.push(uig.clone());
+    pub fn check_params(&self, def_id: DefId) {
+        let body = self.tcx.optimized_mir(def_id);
+        let locals = body.local_decls.clone();
+        let fn_sig = self.tcx.fn_sig(def_id).skip_binder();
+        let param_len = fn_sig.inputs().skip_binder().len();
+        let return_ty = fn_sig.output().skip_binder();
+        for idx in 1..param_len + 1 {
+            let local_ty = locals[Local::from(idx)].ty;
+            if is_ptr(local_ty) && !return_ty.is_unit() {
+                println!("{:?}", get_cleaned_def_path_name(self.tcx, def_id));
             }
         }
+    }
 
-        let mut no_unsafe_con = Vec::new();
-        for uig in pro1 {
-            let mut flag = 0;
-            for con in &uig.caller_cons {
-                if con.1 == true {
-                    flag = 1;
+    pub fn analyze_uig(&self) {
+        let mut func_nc = Vec::new();
+        let mut func_pro1 = Vec::new();
+        let mut func_enc1 = Vec::new();
+        let mut m_nc = Vec::new();
+        let mut m_pro1 = Vec::new();
+        let mut m_enc1 = Vec::new();
+        for uig in &self.uigs {
+            if uig.caller.2 == 1 {
+                // method
+                if uig.caller.1 == true {
+                    m_pro1.push(uig.clone());
+                } else if uig.caller.1 != true {
+                    m_enc1.push(uig.clone());
+                }
+            } else {
+                //function
+                if uig.caller.1 == true {
+                    func_pro1.push(uig.clone());
+                } else if uig.caller.1 != true {
+                    func_enc1.push(uig.clone());
                 }
             }
-            if flag == 0 {
-                no_unsafe_con.push(uig.clone());
+        }
+        for uig in &self.single {
+            if uig.caller.2 == 1 {
+                // method
+                m_nc.push(uig.clone());
+            } else {
+                func_nc.push(uig.clone());
             }
         }
+        println!(
+            "func: {},{},{}, method: {},{},{}",
+            func_nc.len(),
+            func_pro1.len(),
+            func_enc1.len(),
+            m_nc.len(),
+            m_pro1.len(),
+            m_enc1.len()
+        );
+        println!("units: {}", self.uigs.len() + self.single.len());
+        // let mut no_unsafe_con = Vec::new();
+        // for uig in pro1 {
+        //     let mut flag = 0;
+        //     for con in &uig.caller_cons {
+        //         if con.1 == true {
+        //             flag = 1;
+        //         }
+        //     }
+        //     if flag == 0 {
+        //         no_unsafe_con.push(uig.clone());
+        //     }
+        // }
     }
 
     pub fn analyze_struct(&self) {
         let mut cache = HashSet::new();
+        let mut s = 0;
+        let mut u = 0;
+        let mut e = 0;
+        let mut uc = 0;
+        let mut vi = 0;
         for uig in &self.uigs {
-            self.get_struct(uig.caller.0, &mut cache);
+            self.get_struct(
+                uig.caller.0,
+                &mut cache,
+                &mut s,
+                &mut u,
+                &mut e,
+                &mut uc,
+                &mut vi,
+            );
         }
         for uig in &self.single {
-            self.get_struct(uig.caller.0, &mut cache);
+            self.get_struct(
+                uig.caller.0,
+                &mut cache,
+                &mut s,
+                &mut u,
+                &mut e,
+                &mut uc,
+                &mut vi,
+            );
         }
+        println!("{},{},{},{}", s, u, e, vi);
     }
 
-    pub fn get_struct(&self, def_id: DefId, cache: &mut HashSet<DefId>) {
+    pub fn get_struct(
+        &self,
+        def_id: DefId,
+        cache: &mut HashSet<DefId>,
+        s: &mut usize,
+        u: &mut usize,
+        e: &mut usize,
+        uc: &mut usize,
+        vi: &mut usize,
+    ) {
         let tcx = self.tcx;
         let mut safe_constructors = Vec::new();
         let mut unsafe_constructors = Vec::new();
@@ -144,6 +231,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         let mut mut_methods = Vec::new();
         let mut struct_name = "".to_string();
         let mut ty_flag = 0;
+        let mut vi_flag = false;
         if let Some(assoc_item) = tcx.opt_associated_item(def_id) {
             if let Some(impl_id) = assoc_item.impl_container(tcx) {
                 // get struct ty
@@ -159,20 +247,20 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                     if !cache.insert(adt_def_id) {
                         return;
                     }
-                    if !check_visibility(self.tcx, adt_def_id) {
-                        return;
-                    }
+
+                    vi_flag = false;
                     let impl_vec = get_impls_for_struct(self.tcx, adt_def_id);
                     for impl_id in impl_vec {
                         let associated_items = tcx.associated_items(impl_id);
                         for item in associated_items.in_definition_order() {
                             if let ty::AssocKind::Fn = item.kind {
                                 let item_def_id = item.def_id;
-                                if !check_visibility(self.tcx, item_def_id) {
-                                    continue;
+                                if get_sp(self.tcx, item_def_id).len() > 0 {
+                                    vi_flag = true;
                                 }
                                 if get_type(self.tcx, item_def_id) == 0
                                     && check_safety(self.tcx, item_def_id) == true
+                                // && get_sp(self.tcx, item_def_id).len() > 0
                                 {
                                     unsafe_constructors.push(item_def_id);
                                 }
@@ -183,6 +271,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                                 }
                                 if get_type(self.tcx, item_def_id) == 1
                                     && check_safety(self.tcx, item_def_id) == true
+                                // && get_sp(self.tcx, item_def_id).len() > 0
                                 {
                                     unsafe_methods.push(item_def_id);
                                 }
@@ -211,32 +300,42 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         {
             return;
         }
+        if vi_flag {
+            *vi += 1;
+        }
+        if unsafe_constructors.len() > 0 {
+            *uc += 1;
+        }
         if ty_flag == 0 {
-            println!("Struct:{:?}", struct_name);
+            *s += 1;
+            // println!("Struct:{:?}", struct_name);
         }
         if ty_flag == 1 {
-            println!("Union:{:?}", struct_name);
+            *u += 1;
+            // println!("Union:{:?}", struct_name);
         }
         if ty_flag == 2 {
-            println!("Enum:{:?}", struct_name);
+            *e += 1;
+            // println!("Enum:{:?}", struct_name);
         }
-        println!("Safe Cons: {}", safe_constructors.len());
+
+        // println!("Safe Cons: {}", safe_constructors.len());
         // for safe_cons in safe_constructors {
         //     println!(" {:?}", get_cleaned_def_path_name(tcx, safe_cons));
         // }
-        println!("Unsafe Cons: {}", unsafe_constructors.len());
+        // println!("Unsafe Cons: {}", unsafe_constructors.len());
         // for unsafe_cons in unsafe_constructors {
         //     println!(" {:?}", get_cleaned_def_path_name(tcx, unsafe_cons));
         // }
-        println!("Unsafe Methods: {}", unsafe_methods.len());
+        // println!("Unsafe Methods: {}", unsafe_methods.len());
         // for method in unsafe_methods {
         //     println!(" {:?}", get_cleaned_def_path_name(tcx, method));
         // }
-        println!("Safe Methods with unsafe callee: {}", safe_methods.len());
+        // println!("Safe Methods with unsafe callee: {}", safe_methods.len());
         // for method in safe_methods {
         //     println!(" {:?}", get_cleaned_def_path_name(tcx, method));
         // }
-        println!("Mut self Methods: {}", mut_methods.len());
+        // println!("Mut self Methods: {}", mut_methods.len());
         // for method in mut_methods {
         //     println!(" {:?}", get_cleaned_def_path_name(tcx, method));
         // }
@@ -252,9 +351,7 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
                 continue;
             }
             if tcx.def_kind(def_id) == DefKind::Fn || tcx.def_kind(def_id) == DefKind::AssocFn {
-                if check_visibility(tcx, def_id) {
-                    self.insert_uig(def_id, get_callees(tcx, def_id), get_cons(tcx, def_id));
-                }
+                self.insert_uig(def_id, get_callees(tcx, def_id), get_cons(tcx, def_id));
             }
         }
         for uig in &self.uigs {
@@ -263,7 +360,6 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         for single in &self.single {
             single.count_basic_units(&mut basic_units_data);
         }
-        println!("basic_units_data : {:?}", basic_units_data);
     }
 
     pub fn process_def_id(
@@ -312,24 +408,25 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         }
     }
 
-    pub fn filter_mir(def_id: DefId) -> bool {
-        let def_id_fmt = format!("{:?}", def_id);
-        def_id_fmt.contains("core_arch")
-            || def_id_fmt.contains("::__")
-            || def_id_fmt.contains("backtrace_rs")
-            || def_id_fmt.contains("stack_overflow")
-            || def_id_fmt.contains("thread_local")
-            || def_id_fmt.contains("raw_vec")
-            || def_id_fmt.contains("sys_common")
-            || def_id_fmt.contains("adapters")
-            || def_id_fmt.contains("sys::sync")
-            || def_id_fmt.contains("personality")
-            || def_id_fmt.contains("collections::btree::borrow")
-            || def_id_fmt.contains("num::int_sqrt")
-            || def_id_fmt.contains("collections::btree::node")
-            || def_id_fmt.contains("collections::btree::navigate")
-            || def_id_fmt.contains("core_simd")
-            || def_id_fmt.contains("unique")
+    pub fn filter_mir(_def_id: DefId) -> bool {
+        // let def_id_fmt = format!("{:?}", def_id);
+        return false;
+        // def_id_fmt.contains("core_arch")
+        //     || def_id_fmt.contains("::__")
+        //     || def_id_fmt.contains("backtrace_rs")
+        //     || def_id_fmt.contains("stack_overflow")
+        //     || def_id_fmt.contains("thread_local")
+        //     || def_id_fmt.contains("raw_vec")
+        //     || def_id_fmt.contains("sys_common")
+        //     || def_id_fmt.contains("adapters")
+        //     || def_id_fmt.contains("sys::sync")
+        //     || def_id_fmt.contains("personality")
+        //     || def_id_fmt.contains("collections::btree::borrow")
+        //     || def_id_fmt.contains("num::int_sqrt")
+        //     || def_id_fmt.contains("collections::btree::node")
+        //     || def_id_fmt.contains("collections::btree::navigate")
+        //     || def_id_fmt.contains("core_simd")
+        //     || def_id_fmt.contains("unique")
     }
 
     pub fn insert_uig(
@@ -346,6 +443,12 @@ impl<'tcx> UnsafetyIsolationCheck<'tcx> {
         if !check_safety(self.tcx, caller) && callee_set.len() == 0 {
             return;
         }
+        // if check_safety(self.tcx, caller)
+        // && get_sp(self.tcx, caller).len() == 0
+        // {
+        //     println!("{:?}",get_cleaned_def_path_name(self.tcx, caller));
+        //     return;
+        // }
         let uig = UigUnit::new_by_pair(generate_node_ty(self.tcx, caller), caller_cons, pairs);
         if callee_set.len() > 0 {
             self.uigs.push(uig);

--- a/rapx/src/analysis/utils/fn_info.rs
+++ b/rapx/src/analysis/utils/fn_info.rs
@@ -187,7 +187,6 @@ pub fn get_type(tcx: TyCtxt<'_>, def_id: DefId) -> usize {
                     if let Some(impl_id) = assoc_item.impl_container(tcx) {
                         let ty = tcx.type_of(impl_id).skip_binder();
                         if *ref_ty == ty {
-                            println!("find ref:{:?}", output);
                             node_type = 0;
                         }
                     }
@@ -230,7 +229,6 @@ pub fn get_cons(tcx: TyCtxt<'_>, def_id: DefId) -> Vec<NodeType> {
                         if (tcx.def_kind(item) == DefKind::Fn
                             || tcx.def_kind(item) == DefKind::AssocFn)
                             && get_type(tcx, *item) == 0
-                            && check_visibility(tcx, *item)
                         {
                             cons.push(generate_node_ty(tcx, *item));
                         }
@@ -252,7 +250,7 @@ pub fn get_callees(tcx: TyCtxt<'_>, def_id: DefId) -> HashSet<DefId> {
                     if let Operand::Constant(func_constant) = func {
                         if let ty::FnDef(ref callee_def_id, _) = func_constant.const_.ty().kind() {
                             if check_safety(tcx, *callee_def_id)
-                                && check_visibility(tcx, *callee_def_id)
+                            // && check_visibility(tcx, *callee_def_id)
                             {
                                 let sp_set = get_sp(tcx, *callee_def_id);
                                 if sp_set.len() != 0 {
@@ -337,7 +335,9 @@ pub fn get_all_mutable_methods(tcx: TyCtxt<'_>, def_id: DefId) -> HashSet<DefId>
         for item in associated_items.in_definition_order() {
             if let ty::AssocKind::Fn = item.kind {
                 let item_def_id = item.def_id;
-                if has_mut_self_param(tcx, item_def_id) && check_visibility(tcx, item_def_id) {
+                if has_mut_self_param(tcx, item_def_id)
+                // && check_visibility(tcx, item_def_id)
+                {
                     results.insert(item_def_id);
                 }
             }


### PR DESCRIPTION
Previous alias results have redundant pairs like Alias(1,2) and Alias(2,1) for the indexes don't sort by value. 

This PR add an auxiliary method named `sort_alias_index` in `FnRetAlias` and update the SP names in std_sps.json.