### PR TITLE
refactor: add uniform Analysis & AliasAnalysis trait and restructure alias module

### DIFF
--- a/rapx/src/analysis.rs
+++ b/rapx/src/analysis.rs
@@ -5,3 +5,11 @@ pub mod safedrop;
 pub mod senryx;
 pub mod unsafety_isolation;
 pub mod utils;
+
+pub trait Analysis<Q, R> {
+    /// Returns the name of the analysis.
+    fn name(&self) -> &'static str;
+
+    /// returns the result for the given query.
+    fn get(&mut self, query: Q) -> R;
+}

--- a/rapx/src/analysis/core/alias/mop.rs
+++ b/rapx/src/analysis/core/alias/mop.rs
@@ -3,24 +3,152 @@ pub mod graph;
 pub mod mop;
 pub mod types;
 
-use crate::analysis::core::alias::{FnMap, RetAlias};
+use crate::analysis::core::alias::AAFact;
+use crate::analysis::core::alias::{AAResult, AliasAnalysis};
 use crate::analysis::utils::intrinsic_id::{
     COPY_FROM, COPY_FROM_NONOVERLAPPING, COPY_TO, COPY_TO_NONOVERLAPPING,
 };
+use crate::analysis::Analysis;
 use crate::utils::source::*;
 use crate::{rap_debug, rap_info, rap_trace};
 use graph::MopGraph;
 use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
-use rustc_span::def_id::DefId;
 use std::collections::HashSet;
 
 pub const VISIT_LIMIT: usize = 1000;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct MopAAFact {
+    pub fact: AAFact,
+    pub lhs_may_drop: bool,
+    pub lhs_need_drop: bool,
+    pub rhs_may_drop: bool,
+    pub rhs_need_drop: bool,
+}
+
+impl MopAAFact {
+    pub fn new(
+        lhs_no: usize,
+        lhs_may_drop: bool,
+        lhs_need_drop: bool,
+        rhs_no: usize,
+        rhs_may_drop: bool,
+        rhs_need_drop: bool,
+    ) -> MopAAFact {
+        MopAAFact {
+            fact: AAFact::new(lhs_no, rhs_no),
+            lhs_may_drop,
+            lhs_need_drop,
+            rhs_may_drop,
+            rhs_need_drop,
+        }
+    }
+
+    pub fn valuable(&self) -> bool {
+        return self.lhs_may_drop && self.rhs_may_drop;
+    }
+
+    pub fn swap(&mut self) {
+        self.fact.swap();
+        std::mem::swap(&mut self.lhs_may_drop, &mut self.rhs_may_drop);
+        std::mem::swap(&mut self.lhs_need_drop, &mut self.rhs_need_drop);
+    }
+
+    pub fn lhs_no(&self) -> usize {
+        self.fact.lhs_no
+    }
+
+    pub fn rhs_no(&self) -> usize {
+        self.fact.rhs_no
+    }
+
+    pub fn lhs_fields(&self) -> &[usize] {
+        &self.fact.lhs_fields
+    }
+
+    pub fn rhs_fields(&self) -> &[usize] {
+        &self.fact.rhs_fields
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MopAAResult {
+    arg_size: usize,
+    alias_set: HashSet<MopAAFact>,
+}
+
+impl MopAAResult {
+    pub fn new(arg_size: usize) -> MopAAResult {
+        Self {
+            arg_size,
+            alias_set: HashSet::new(),
+        }
+    }
+
+    pub fn arg_size(&self) -> usize {
+        self.arg_size
+    }
+
+    pub fn aliases(&self) -> &HashSet<MopAAFact> {
+        &self.alias_set
+    }
+
+    pub fn add_alias(&mut self, alias: MopAAFact) {
+        self.alias_set.insert(alias);
+    }
+
+    pub fn len(&self) -> usize {
+        self.alias_set.len()
+    }
+
+    pub fn sort_alias_index(&mut self) {
+        let alias_set = std::mem::take(&mut self.alias_set);
+        let mut new_alias_set = HashSet::with_capacity(alias_set.len());
+
+        for mut ra in alias_set.into_iter() {
+            if ra.lhs_no() >= ra.rhs_no() {
+                ra.swap();
+            }
+            new_alias_set.insert(ra);
+        }
+        self.alias_set = new_alias_set;
+    }
+}
+
+impl Into<AAResult> for MopAAResult {
+    fn into(self) -> AAResult {
+        AAResult {
+            arg_size: self.arg_size,
+            alias_set: self.alias_set.into_iter().map(|alias| alias.fact).collect(),
+        }
+    }
+}
+
+//struct to cache the results for analyzed functions.
+pub type FnMap = FxHashMap<DefId, MopAAResult>;
 
 pub struct MopAlias<'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub fn_map: FnMap,
 }
+
+impl<'tcx> Analysis<DefId, AAResult> for MopAlias<'tcx> {
+    fn name(&self) -> &'static str {
+        "Alias Analysis (MoP)"
+    }
+
+    fn get(&mut self, query: DefId) -> AAResult {
+        self.fn_map
+            .get(&query)
+            .expect(&format!("cannot find alias analysis result for {query:?}"))
+            .clone()
+            .into()
+    }
+}
+
+impl<'tcx> AliasAnalysis for MopAlias<'tcx> {}
 
 impl<'tcx> MopAlias<'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>) -> Self {
@@ -41,7 +169,7 @@ impl<'tcx> MopAlias<'tcx> {
             let fn_name = get_fn_name(self.tcx, *fn_id);
             fn_alias.sort_alias_index();
             if fn_alias.len() > 0 {
-                rap_info!("Alias found in {:?}: {}", fn_name, fn_alias);
+                rap_info!("Alias found in {:?}: {:?}", fn_name, fn_alias);
             }
         }
         self.handle_conor_cases();
@@ -55,7 +183,7 @@ impl<'tcx> MopAlias<'tcx> {
             COPY_TO,
             COPY_FROM,
         ];
-        let alias = RetAlias::new(1, true, true, 2, true, true);
+        let alias = MopAAFact::new(1, true, true, 2, true, true);
         for (key, value) in self.fn_map.iter_mut() {
             if cases.contains(&key.index.as_usize()) {
                 value.alias_set.clear();

--- a/rapx/src/analysis/core/alias/mop.rs
+++ b/rapx/src/analysis/core/alias/mop.rs
@@ -16,6 +16,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
 use std::collections::HashSet;
+use std::fmt;
 
 pub const VISIT_LIMIT: usize = 1000;
 
@@ -77,6 +78,21 @@ impl MopAAFact {
 pub struct MopAAResult {
     arg_size: usize,
     alias_set: HashSet<MopAAFact>,
+}
+
+
+impl fmt::Display for MopAAResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{{{}}}",
+            self.aliases()
+                .iter()
+                .map(|alias| format!("{}", alias.fact))
+                .collect::<Vec<String>>()
+                .join(",")
+        )
+    }
 }
 
 impl MopAAResult {
@@ -169,7 +185,7 @@ impl<'tcx> MopAlias<'tcx> {
             let fn_name = get_fn_name(self.tcx, *fn_id);
             fn_alias.sort_alias_index();
             if fn_alias.len() > 0 {
-                rap_info!("Alias found in {:?}: {:?}", fn_name, fn_alias);
+                rap_info!("Alias found in {:?}: {}", fn_name, fn_alias);
             }
         }
         self.handle_conor_cases();

--- a/rapx/src/analysis/core/alias/mop/graph.rs
+++ b/rapx/src/analysis/core/alias/mop/graph.rs
@@ -1,5 +1,5 @@
 use super::types::*;
-use crate::analysis::core::alias::FnRetAlias;
+use crate::analysis::core::alias::mop::MopAAResult;
 use crate::rap_debug;
 use crate::utils::source::*;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
@@ -146,7 +146,7 @@ pub struct MopGraph<'tcx> {
     // record the constant value during safedrop checking, i.e., which id has what value.
     pub constant: FxHashMap<usize, usize>,
     // contains the return results for inter-procedure analysis.
-    pub ret_alias: FnRetAlias,
+    pub ret_alias: MopAAResult,
     // a threhold to avoid path explosion.
     pub visit_times: usize,
     pub alias_set: Vec<usize>,
@@ -452,7 +452,7 @@ impl<'tcx> MopGraph<'tcx> {
             scc_indices,
             alias_set: alias,
             constant: FxHashMap::default(),
-            ret_alias: FnRetAlias::new(arg_size),
+            ret_alias: MopAAResult::new(arg_size),
             visit_times: 0,
             child_scc: FxHashMap::default(),
             disc_map,

--- a/rapx/src/analysis/safedrop.rs
+++ b/rapx/src/analysis/safedrop.rs
@@ -10,8 +10,7 @@ pub mod types;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
 
-use crate::analysis::core::alias::mop::MopAlias;
-use crate::analysis::core::alias::FnMap;
+use crate::analysis::core::alias::mop::{FnMap, MopAlias};
 use crate::analysis::core::heap_item::{AdtOwner, TypeAnalysis};
 use crate::analysis::rcanary::rCanary;
 use graph::SafeDropGraph;

--- a/rapx/src/analysis/safedrop/safedrop.rs
+++ b/rapx/src/analysis/safedrop/safedrop.rs
@@ -1,12 +1,11 @@
+use crate::analysis::core::alias::mop::FnMap;
+use crate::analysis::safedrop::SafeDropGraph;
+use crate::rap_error;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_middle::mir::Operand::{Constant, Copy, Move};
 use rustc_middle::mir::{Operand, Place, TerminatorKind};
 use rustc_middle::ty::{TyCtxt, TyKind, TypingEnv};
 use std::collections::{HashMap, HashSet};
-
-use crate::analysis::core::alias::FnMap;
-use crate::analysis::safedrop::SafeDropGraph;
-use crate::rap_error;
 
 pub const VISIT_LIMIT: usize = 1000;
 

--- a/rapx/src/analysis/senryx.rs
+++ b/rapx/src/analysis/senryx.rs
@@ -24,8 +24,7 @@ use rustc_middle::ty::TyCtxt;
 use std::collections::{HashMap, HashSet};
 use visitor::{BodyVisitor, CheckResult};
 
-use super::core::alias::mop::MopAlias;
-use super::core::alias::FnMap;
+use super::core::alias::mop::{FnMap, MopAlias};
 
 macro_rules! cond_print {
     ($cond:expr, $($t:tt)*) => {if $cond {rap_warn!($($t)*)} else {rap_info!($($t)*)}};

--- a/rapx/src/analysis/senryx/visitor.rs
+++ b/rapx/src/analysis/senryx/visitor.rs
@@ -1,4 +1,4 @@
-use crate::analysis::core::alias::FnMap;
+use crate::analysis::core::alias::mop::FnMap;
 use crate::analysis::safedrop::graph::SafeDropGraph;
 use crate::analysis::utils::fn_info::display_hashmap;
 use crate::analysis::utils::fn_info::get_all_std_unsafe_callees_block_id;
@@ -444,10 +444,10 @@ impl<'tcx> BodyVisitor<'tcx> {
         // If one of the op is ptr, then alias the pointed node with another.
         if let Some(retalias) = fn_map.get(def_id) {
             for alias_set in retalias.aliases() {
-                let (l, r) = (alias_set.left_index, alias_set.right_index);
+                let (l, r) = (alias_set.fact.lhs_no, alias_set.fact.rhs_no);
                 let (l_fields, r_fields) = (
-                    alias_set.left_field_seq.clone(),
-                    alias_set.right_field_seq.clone(),
+                    alias_set.fact.lhs_fields.clone(),
+                    alias_set.fact.rhs_fields.clone(),
                 );
                 let (l_place, r_place) = (
                     if l != 0 {

--- a/rapx/src/lib.rs
+++ b/rapx/src/lib.rs
@@ -42,8 +42,6 @@ use rustc_session::search_paths::PathKind;
 use std::path::PathBuf;
 use std::{env, sync::Arc};
 
-use crate::analysis::core::range_analysis::RangeAnalysisStrategy;
-
 // Insert rustc arguments at the beginning of the argument list that RAP wants to be
 // set per default, for maximal validation power.
 pub static RAP_DEFAULT_ARGS: &[&str] = &["-Zalways-encode-mir", "-Zmir-opt-level=0"];


### PR DESCRIPTION
Summary of this PR:
- Introduces a unified Analysis and AliasAnalysis trait.
- Refactors the alias module:
    - Renames key data structures to improve readability.
    - AAFact and AAResult now only store common information shared across alias analysis results.
    - Algorithm-specific data (e.g., left_need_drop, right_may_drop) has been moved to corresponding submodules.
- Updates downstream modules to ensure the codebase remains compilable.