### PR TITLE
refactor dataflow analysis

### DIFF
--- a/rapx/Cargo.lock
+++ b/rapx/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "rapx"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "annotate-snippets",
  "cargo_metadata",

--- a/rapx/src/analysis/opt.rs
+++ b/rapx/src/analysis/opt.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty::TyCtxt;
 use crate::rap_warn;
 use crate::utils::log::span_to_source_code;
 
-use super::core::dataflow::{graph::Graph, DataFlow};
+use super::core::dataflow::{graph::Graph, DataFlowAnalyzer};
 use checking::bounds_checking::BoundsCheck;
 use checking::encoding_checking::EncodingCheck;
 use data_collection::initialization::InitializationCheck;
@@ -52,7 +52,7 @@ impl<'tcx> Opt<'tcx> {
     }
 
     pub fn start(&mut self) {
-        let mut dataflow = DataFlow::new(self.tcx, false);
+        let mut dataflow = DataFlowAnalyzer::new(self.tcx, false);
         dataflow.build_graphs();
         {
             let mut no_std = NO_STD.lock().unwrap();

--- a/rapx/src/lib.rs
+++ b/rapx/src/lib.rs
@@ -26,7 +26,7 @@ use analysis::{
         alias_analysis::default::AliasAnalyzer,
         api_dep::ApiDep,
         callgraph::default::CallGraphAnalyzer,
-        dataflow::DataFlow,
+        dataflow::DataFlowAnalyzer,
         ownedheap_analysis::{default::OwnedHeapAnalyzer, OwnedHeapAnalysis},
         range_analysis::RangeAnalyzer,
         ssa_pass_runner::SSATrans,
@@ -327,8 +327,8 @@ pub fn start_analyzer(tcx: TyCtxt, callback: RapCallback) {
     }
 
     match callback.is_dataflow_enabled() {
-        1 => DataFlow::new(tcx, false).start(),
-        2 => DataFlow::new(tcx, true).start(),
+        1 => DataFlowAnalyzer::new(tcx, false).run(),
+        2 => DataFlowAnalyzer::new(tcx, true).run(),
         _ => {}
     }
 


### PR DESCRIPTION
Temporally define two funcs in DataFlowAnalysis
- fn has_flow_between(&self, def_id: DefId, local1: Local, local2: Local) -> bool;
- fn collect_equivalent_locals(&self, def_id: DefId, local: Local) -> HashSet<Local>;