### PR TITLE
Modify the Display trait of DataFlowGraph

### DIFF
--- a/rapx/src/analysis/core/dataflow/default.rs
+++ b/rapx/src/analysis/core/dataflow/default.rs
@@ -28,6 +28,11 @@ impl<'tcx> DataFlowAnalysis for DataFlowAnalyzer<'tcx> {
         let graph = self.graphs.get(&def_id).unwrap();
         graph.collect_equivalent_locals(local, true)
     }
+
+    fn param_return_deps(&self, def_id: DefId) -> IndexVec<Local, bool> {
+        let graph = self.graphs.get(&def_id).unwrap();
+        graph.param_return_deps()
+    }
 }
 
 impl<'tcx> Analysis for DataFlowAnalyzer<'tcx> {
@@ -37,6 +42,9 @@ impl<'tcx> Analysis for DataFlowAnalyzer<'tcx> {
 
     fn run(&mut self) {
         self.build_graphs();
+        if self.debug {
+            self.draw_graphs();
+        }
     }
 
     fn reset(&mut self) {

--- a/rapx/src/analysis/core/dataflow/graph.rs
+++ b/rapx/src/analysis/core/dataflow/graph.rs
@@ -39,9 +39,11 @@ pub struct Graph {
 
 impl From<Graph> for DataFlowGraph {
     fn from(graph: Graph) -> Self {
+        let param_ret_deps = graph.param_return_deps();
         DataFlowGraph {
             nodes: graph.nodes,
             edges: graph.edges,
+            param_ret_deps: param_ret_deps,
         }
     }
 }
@@ -408,7 +410,7 @@ impl Graph {
             Direction::Downside,
             &mut node_operator,
             &mut Self::always_true_edge_validator,
-            false,
+            true,
             &mut seen,
         );
         seen.clear();
@@ -418,7 +420,7 @@ impl Graph {
                 Direction::Upside,
                 &mut node_operator,
                 &mut Self::always_true_edge_validator,
-                false,
+                true,
                 &mut seen,
             );
         }


### PR DESCRIPTION
1. Fix bug of param_return_deps in dataflow::Graph
2. Simplify the display string of DataFlowGraph
3. Keep the original implementation as Debug trait