### PR TITLE
Fix:  replace `tcx.mir_keys()` by rustc_public API in `unsafety_isolation`

### DIFF
--- a/rapx/src/def_id.rs
+++ b/rapx/src/def_id.rs
@@ -1,7 +1,5 @@
 extern crate indexmap;
-extern crate rustc_public;
 
-// use crate::rap_info;
 use indexmap::IndexMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
@@ -15,9 +13,7 @@ struct Intrinsics {
 }
 
 pub fn init(tcx: TyCtxt) {
-    INIT.get_or_init(|| {
-        rustc_internal::run(tcx, || init_inner(tcx)).expect("Failed to run rustc_public.")
-    });
+    INIT.get_or_init(|| init_inner(tcx));
 }
 
 fn init_inner(tcx: TyCtxt) -> Intrinsics {

--- a/rapx/src/def_id.rs
+++ b/rapx/src/def_id.rs
@@ -77,3 +77,8 @@ intrinsics! {
     drop_in_place: "std::ptr::drop_in_place",
     manually_drop: "std::mem::ManuallyDrop::<T>::drop",
 }
+
+/// rustc_public DefId to internal DefId
+pub fn to_internal<T: CrateDef>(val: &T, tcx: TyCtxt) -> DefId {
+    rustc_internal::internal(tcx, val.def_id())
+}

--- a/rapx/src/lib.rs
+++ b/rapx/src/lib.rs
@@ -1,10 +1,12 @@
 #![feature(rustc_private)]
 #![feature(box_patterns)]
 
+#[macro_use]
+pub mod utils;
+
 pub mod analysis;
 pub mod def_id;
 pub mod preprocess;
-pub mod utils;
 extern crate intervals;
 extern crate rustc_abi;
 extern crate rustc_ast;

--- a/rapx/src/lib.rs
+++ b/rapx/src/lib.rs
@@ -17,6 +17,7 @@ extern crate rustc_index;
 extern crate rustc_interface;
 extern crate rustc_metadata;
 extern crate rustc_middle;
+extern crate rustc_public;
 extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
@@ -132,7 +133,10 @@ impl Callbacks for RapCallback {
     }
     fn after_analysis<'tcx>(&mut self, _compiler: &Compiler, tcx: TyCtxt<'tcx>) -> Compilation {
         rap_trace!("Execute after_analysis() of compiler callbacks");
-        start_analyzer(tcx, self);
+        rustc_public::rustc_internal::run(tcx, || {
+            start_analyzer(tcx, self);
+        })
+        .expect("Failed to run rustc_public.");
         rap_trace!("analysis done");
         Compilation::Continue
     }

--- a/rapx/src/utils/mod.rs
+++ b/rapx/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod fs;
+#[macro_use]
 pub mod log;
 pub mod source;


### PR DESCRIPTION
<img width="1402" height="227" alt="截图_20250826100011" src="https://github.com/user-attachments/assets/73f699bd-6b67-4d18-bf77-f85193ac0c18" />
