### PR TITLE
Fix: handle `#![no_std]` crates when retrieving intrinsics DefIds

### DIFF
--- a/rapx/src/analysis/safedrop/graph.rs
+++ b/rapx/src/analysis/safedrop/graph.rs
@@ -394,10 +394,12 @@ impl<'tcx> SafeDropGraph<'tcx> {
                 } => {
                     if let Operand::Constant(c) = func {
                         if let &ty::FnDef(id, ..) = c.ty().kind() {
+                            // for no_std crates without using alloc,
+                            // dealloc will be never found, thus call dealloc_opt here
                             if id == drop()
                                 || id == drop_in_place()
                                 || id == manually_drop()
-                                || id == dealloc()
+                                || dealloc_opt().map(|f| f == id).unwrap_or(false)
                             {
                                 cur_bb.drops.push(terminator.clone());
                             }

--- a/rapx/src/def_id.rs
+++ b/rapx/src/def_id.rs
@@ -9,7 +9,8 @@ use std::sync::OnceLock;
 static INIT: OnceLock<Intrinsics> = OnceLock::new();
 
 struct Intrinsics {
-    map: IndexMap<&'static str, DefId>,
+    // The key is fn path, starting from `core::` or `std::`. The value is internal def id.
+    map: IndexMap<Box<str>, DefId>,
 }
 
 pub fn init(tcx: TyCtxt) {
@@ -19,20 +20,32 @@ pub fn init(tcx: TyCtxt) {
 fn init_inner(tcx: TyCtxt) -> Intrinsics {
     const CRATES: &[&str] = &["core", "std", "alloc"];
 
-    let mut map = IndexMap::with_capacity(INTRINSICS.len());
+    // The key is an index to INTRINSICS slice; the value means if the path is found.
+    let mut indices: IndexMap<_, _> = (0..INTRINSICS.len()).map(|idx| (idx, false)).collect();
+
+    let mut map = IndexMap::<Box<str>, DefId>::with_capacity(INTRINSICS.len());
     for krate in rustc_public::external_crates() {
         if !CRATES.iter().any(|name| *name == krate.name) {
             continue;
         }
+
         for fn_def in krate.fn_defs() {
             let fn_name = fn_def.name();
-            if let Some(name) = INTRINSICS
-                .iter()
-                .find_map(|&name| (name == fn_name).then_some(name))
-            {
-                // if INTRINSICS.iter().any(|name| fn_name.contains(name)) {
+            if let Some(name) = INTRINSICS.iter().enumerate().find_map(|(idx, paths)| {
+                if paths.iter().any(|path| **path == fn_name) {
+                    assert_eq!(
+                        indices.insert(idx, true),
+                        Some(false),
+                        "DefId for {fn_name} has been found: {:?}",
+                        map.get(&*fn_name)
+                    );
+                    Some(fn_name.as_str().into())
+                } else {
+                    None
+                }
+            }) {
                 let def_id = rustc_internal::internal(tcx, fn_def.def_id());
-                if map.contains_key(name) {
+                if map.contains_key(&name) {
                     panic!("DefId of {fn_name} has been inserted: {def_id:?}");
                 } else {
                     map.insert(name, def_id);
@@ -42,40 +55,87 @@ fn init_inner(tcx: TyCtxt) -> Intrinsics {
     }
 
     map.sort_unstable_by(|a, _, b, _| a.cmp(b));
+
+    let not_found = indices
+        .iter()
+        .filter_map(|(&idx, &found)| (!found).then_some(INTRINSICS[idx]))
+        .collect::<Vec<_>>();
     assert_eq!(
         INTRINSICS.len(),
         map.len(),
         "Intrinsic functions is incompletely retrieved.\n\
-         INTRINSICS = {INTRINSICS:#?}\nmap ={map:#?}"
+         {} fn ids are not found: {not_found:#?}",
+        not_found.len()
     );
-    // rap_info!("Intrinsic = {map:#?}");
+
     Intrinsics { map }
 }
 
 macro_rules! intrinsics {
-    ($( $id:ident : $call:literal ,)+ ) => {
-        const INTRINSICS: &[&str] = &[$($call,)+];
+    ($( $id:ident : $paths:expr ,)+ ) => {
+        const INTRINSICS: &[&[&str]] = &[$( $paths ,)+];
         $(
             pub fn $id() -> DefId {
-                *INIT.get().expect("Intrinsics DefIds haven't been initialized.").map.get($call)
-                    .unwrap_or_else(|| panic!("Failed to retrieve the DefId of {}.", $call))
+                let map = &INIT.get().expect("Intrinsics DefIds haven't been initialized.").map;
+                for path in $paths {
+                    match map.get(*path) {
+                        Some(id) => return *id,
+                        None => ()
+                    }
+                }
+                panic!("Failed to retrieve the DefId of {:#?}.", $paths);
             }
         )+
     };
 }
 
+// for #![no_std] crates, intrinsics fn paths start from core instead of core.
+// cc https://github.com/Artisan-Lab/RAPx/issues/190
 intrinsics! {
-    assume_init_drop: "std::mem::MaybeUninit::<T>::assume_init_drop",
-    call_mut: "std::ops::FnMut::call_mut",
-    clone: "std::clone::Clone::clone",
-    copy_from: "std::ptr::mut_ptr::<impl *mut T>::copy_from",
-    copy_from_nonoverlapping: "std::ptr::mut_ptr::<impl *mut T>::copy_from_nonoverlapping",
-    copy_to: "std::ptr::const_ptr::<impl *const T>::copy_to",
-    copy_to_nonoverlapping: "std::ptr::const_ptr::<impl *const T>::copy_to_nonoverlapping",
-    dealloc: "std::alloc::dealloc",
-    drop: "std::mem::drop",
-    drop_in_place: "std::ptr::drop_in_place",
-    manually_drop: "std::mem::ManuallyDrop::<T>::drop",
+    assume_init_drop: &[
+        "std::mem::MaybeUninit::<T>::assume_init_drop",
+        "core::mem::MaybeUninit::<T>::assume_init_drop"
+    ],
+    call_mut: &[
+        "std::ops::FnMut::call_mut",
+        "core::ops::FnMut::call_mut"
+    ],
+    clone: &[
+        "std::clone::Clone::clone",
+        "core::clone::Clone::clone"
+    ],
+    copy_from: &[
+        "std::ptr::mut_ptr::<impl *mut T>::copy_from",
+        "core::ptr::mut_ptr::<impl *mut T>::copy_from"
+    ],
+    copy_from_nonoverlapping: &[
+        "std::ptr::mut_ptr::<impl *mut T>::copy_from_nonoverlapping",
+        "core::ptr::mut_ptr::<impl *mut T>::copy_from_nonoverlapping"
+    ],
+    copy_to: &[
+        "std::ptr::const_ptr::<impl *const T>::copy_to",
+        "core::ptr::const_ptr::<impl *const T>::copy_to",
+    ],
+    copy_to_nonoverlapping: &[
+        "std::ptr::const_ptr::<impl *const T>::copy_to_nonoverlapping",
+        "core::ptr::const_ptr::<impl *const T>::copy_to_nonoverlapping"
+    ],
+    dealloc: &[
+        "std::alloc::dealloc",
+        "alloc::alloc::dealloc"
+    ],
+    drop: &[
+        "std::mem::drop",
+        "core::mem::drop",
+    ],
+    drop_in_place: &[
+        "std::ptr::drop_in_place",
+        "core::ptr::drop_in_place",
+    ],
+    manually_drop: &[
+        "std::mem::ManuallyDrop::<T>::drop",
+        "core::mem::ManuallyDrop::<T>::drop"
+    ],
 }
 
 /// rustc_public DefId to internal DefId

--- a/rapx/src/lib.rs
+++ b/rapx/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private)]
 #![feature(box_patterns)]
+#![feature(macro_metavar_expr_concat)]
 
 #[macro_use]
 pub mod utils;

--- a/rapx/tests/others/batch.sh
+++ b/rapx/tests/others/batch.sh
@@ -4,6 +4,9 @@
 # #![deny(missing_docs)] must be successfully compiled.
 # cc https://github.com/Artisan-Lab/RAPx/issues/184
 pushd support/deny_missing_docs && cargo rapx -- && popd
+# defid of intrinsics for #![no_std] crates
+# cc https://github.com/Artisan-Lab/RAPx/issues/190
+pushd support/no_std && cargo rapx -alias && popd
 
 # All arguments passed to this script are forwarded to cargo rapx
 # Example: batch.sh -F -M

--- a/rapx/tests/others/support/no_std/Cargo.toml
+++ b/rapx/tests/others/support/no_std/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "no_std"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/rapx/tests/others/support/no_std/src/lib.rs
+++ b/rapx/tests/others/support/no_std/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_std]
+
+// no_std crates without using alloc will never find dealloc:
+// 13:57:47|RAP|WARN|: Intrinsic functions is incompletely retrieved.
+// 1 fn ids are not found: [
+//     [
+//         "std::alloc::dealloc",
+//         "alloc::alloc::dealloc",
+//     ],
+// ]
+// extern crate alloc;


### PR DESCRIPTION
This PR fixes https://github.com/Artisan-Lab/RAPx/issues/190 by
* searching paths of intrinsics in extended paths: intrinsics in no_std crates will be matched against paths starting from core or alloc root
* handling dealloc for no_std crates without alloc via dealloc_opt
  * each intrinsics DefId getter now has an optional variant: e.g. dealloc <=> dealloc_opt
* also adding a no_std testcase