### PR TITLE
feat: add APIs about descending and fields

### DIFF
--- a/rapx/src/analysis/core/dataflow/mod.rs
+++ b/rapx/src/analysis/core/dataflow/mod.rs
@@ -226,7 +226,7 @@ pub enum EdgeOp {
     Mut,
     //Place
     Deref,
-    Field(String),
+    Field(usize),
     Downcast(String),
     Index,
     ConstIndex,


### PR DESCRIPTION
Add two APIs for dataflow Graph:
- `collect_descending_locals`, collecting all locals in the downstream of the specific local
- `get_field_sequence`, get the field sequence of the specific marker node. e.g., foo.a.b.c (will get field numbers of foo, a, and b)